### PR TITLE
update ratatui-image 9.0.0-beta.6 which fixes chafa min version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "9.0.0-beta.4"
+version = "9.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543fe862b07eb2dbcb6519e9351ca9f2586adefcec25c142c32e183965c8a2fd"
+checksum = "1e4c030637a4ee5a8e1551679da58435a40697b87e571ed8d746cf7f0ac0db6b"
 dependencies = [
  "base64-simd",
  "icy_sixel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cosmic-text = "0.14.2"
 image = "0.25.2"
 ratatui = { version = "^0.30.0-beta.0", features = ["serde"] }
 ratskin = "0.3.0"
-ratatui-image = { version = "9.0.0-beta.4", features = ["serde"] }
+ratatui-image = { version = "9.0.0-beta.6", features = ["serde"] }
 regex = "1.11.1"
 unicode-width = "0.2.2"
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
9.0.0-beta.5 wrongly had min chafa version 1.18, it's actually 1.8. NixOS happened to have 1.18, Ubuntu 24.04 has something like 1.14. Anyway, this fixes it.