### PR TITLE
Add macports install option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On terminals without graphics whatsoever, like Alactritty, images are rendered w
 * Nixpkgs: [`mdfried`](https://search.nixos.org/packages?channel=unstable&query=mdfried)
 * Arch Linux: `pacman -S mdfried` ([extra repository](https://archlinux.org/packages/extra/x86_64/mdfried/))
 * Ubuntu: [Download release .deb](https://github.com/benjajaja/mdfried/releases/latest)
-* Mac: `brew install mdfried` or [realease binaries](https://github.com/benjajaja/mdfried/releases/latest)
+* Mac: `brew install mdfried` or `port install mdfried` or [realease binaries](https://github.com/benjajaja/mdfried/releases/latest)
 * Windows: [Download release .exe](https://github.com/benjajaja/mdfried/releases/latest)
 
 # Usage


### PR DESCRIPTION
Hello

thx for creating `mdfried`. I added it to macports (macports/macports-ports#31960)

Updating README to add macports install option.