### PR TITLE
fix list continuations

### DIFF
--- a/mdfrier/src/lib.rs
+++ b/mdfrier/src/lib.rs
@@ -531,6 +531,7 @@ Quote break.
    (This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)
 
 - Unordered list can use asterisks
+  And can also have continuations.
 
 * Or minuses
 
@@ -561,6 +562,23 @@ Quote break.
     - [ ] this is a complete item
     - [ ] this is an incomplete item
 - Very easy!
+"#;
+
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        let output = lines_to_string(&lines);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn list_preserve_continuations() {
+        let input = r#"1. First ordered list item
+2. Another item
+   Continuation of item.
+   Carry on.
+
+   Further continuation.
+3. Last item
 "#;
 
         let mut frier = MdFrier::new().unwrap();

--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -615,9 +615,9 @@ fn wrapped_to_lines<M: Mapper>(
 
         // For continuation lines (soft-wrapped), mark ListItems as continuation
         let line_nesting = if line_idx == 0 || wrapped_line.is_first {
-            nesting.clone()
+            &nesting
         } else {
-            nesting
+            &nesting
                 .iter()
                 .map(|c| match c {
                     MdLineContainer::Blockquote => MdLineContainer::Blockquote,
@@ -635,7 +635,7 @@ fn wrapped_to_lines<M: Mapper>(
             .all(|span| span.modifiers.contains(Modifier::Image));
         // Create text line
         if !is_only_image && !wrapped_line.spans.is_empty() {
-            let mut spans = nesting_to_prefix_spans(&line_nesting, mapper);
+            let mut spans = nesting_to_prefix_spans(line_nesting, mapper);
             spans.extend(wrapped_line.spans);
             lines.push(Line {
                 spans,

--- a/mdfrier/src/markdown.rs
+++ b/mdfrier/src/markdown.rs
@@ -90,6 +90,13 @@ impl Iterator for MdIterator<'_> {
                 let nesting: Vec<MdContainer> =
                     self.context.iter().map(|(_, c)| c.clone()).collect();
 
+                eprintln!("CONTINUATION CHECK");
+                eprintln!("content: {content:?}");
+                if let MdContent::Paragraph(p) = &content {
+                    for span in &p.spans {
+                        eprintln!("\t{span:?}");
+                    }
+                }
                 // Check if this is a continuation within a list item
                 let list_item_depth = self
                     .context
@@ -110,6 +117,11 @@ impl Iterator for MdIterator<'_> {
                 } else {
                     false
                 };
+                eprintln!(
+                    "list_item_depth: {list_item_depth:?}, is_list_continuation: {is_list_continuation}, list_item_content_depth: {:?}",
+                    self.list_item_content_depth
+                );
+                eprintln!("context: {:?}", self.context);
 
                 return Some(MdSection {
                     content,

--- a/mdfrier/src/snapshots/mdfrier__tests__list_preserve_continuations.snap
+++ b/mdfrier/src/snapshots/mdfrier__tests__list_preserve_continuations.snap
@@ -1,0 +1,11 @@
+---
+source: mdfrier/src/lib.rs
+expression: output
+---
+1. First ordered list item
+2. Another item
+   Continuation of item.
+   Carry on.
+
+   Further continuation.
+3. Last item

--- a/mdfrier/src/snapshots/mdfrier__tests__list_preserve_formatting.snap
+++ b/mdfrier/src/snapshots/mdfrier__tests__list_preserve_formatting.snap
@@ -20,6 +20,7 @@ expression: output
    spaces are not required.)
 
 - Unordered list can use asterisks
+  And can also have continuations.
 
 * Or minuses
 

--- a/mdfrier/src/wrap.rs
+++ b/mdfrier/src/wrap.rs
@@ -42,12 +42,6 @@ pub(crate) fn wrap_md_spans(
         .filter(|line| !line.is_empty())
         .enumerate()
         .map(|(line_idx, mdspans)| {
-            let is_source_newline = mdspans
-                .first()
-                .is_some_and(|s| s.modifiers.contains(Modifier::NewLine));
-
-            let is_first = line_idx == 0 || is_source_newline;
-
             // Extract images from spans
             let mut images: Vec<ImageRef> = Vec::new();
             for (i, s) in mdspans.iter().enumerate() {
@@ -79,7 +73,7 @@ pub(crate) fn wrap_md_spans(
             }
 
             WrappedLine {
-                is_first,
+                is_first: line_idx == 0,
                 spans: mdspans,
                 images,
             }


### PR DESCRIPTION
```
1. aaa
   continue
2. bbb
```

was resulting in:

```
1. aaa
1. continue
2. bbb
```

A continuation with an empty line separator and indendation *did* work.

Fixes #90