### PR TITLE
Use open crate instead of hardcoded xdg-open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1640,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1894,6 +1913,7 @@ dependencies = [
  "mdfrier",
  "notify",
  "notify-debouncer-mini",
+ "open",
  "pretty_assertions",
  "ratatui",
  "ratatui-image",
@@ -2176,6 +2196,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2294,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = { version = "0.4.28" }
 mdfrier = { version = "0.3.1", path = "mdfrier", features = ["ratatui"] }
 notify = "8.1.0"
 notify-debouncer-mini = "0.6.0"
+open = "5.3.3"
 ratatui = { version = "^0.30.0", features = ["serde", "crossterm_0_29"] }
 ratatui-image = { version = "10.0.6", default-features = false, features = ["serde"] }
 regex = "1.11.1"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Key | Description
 `/` | Search text
 `n` | Jump to next match or link
 `N` | Jump to previous match or link
-`Enter` | Open selected link with `xdg-open`
+`Enter` | Open selected link with `xdg-open` (linux) or `open` (macos)
 `Esc` | Leave search or link modes
 
 Entering a number before motion applies the motion that many times.
@@ -106,4 +106,3 @@ select text.
 ### Configuration
 
 `~/.config/mdfried/config.toml` is automatically created on first run.
-

--- a/src/model.rs
+++ b/src/model.rs
@@ -274,7 +274,9 @@ impl Model {
     }
 
     pub fn open_link(&self, url: String) -> Result<(), Error> {
-        std::process::Command::new("xdg-open").arg(&url).spawn()?;
+        if let Err(err) = open::that(&url) {
+            log::error!("{err}");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Hello

`xdg-open` does not work on macos, so mdfried exits with io error.

There is open crate that runs platform specific version like `open` for macos.

I tested this change and it fixes io error and opens urls in my default browser.