### PR TITLE
add what-terminal-font subcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,6 +1925,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-md",
  "unicode-width",
+ "what-terminal-font",
 ]
 
 [[package]]
@@ -4243,6 +4244,13 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "what-terminal-font"
+version = "0.1.0"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,7 @@ dependencies = [
 name = "what-terminal-font"
 version = "0.1.0"
 dependencies = [
+ "tempfile",
  "thiserror 1.0.69",
 ]
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,6 +13,7 @@ use crate::{
     error::Error,
 };
 use fontpicker::interactive_font_picker;
+use what_terminal_font::detect_terminal_font;
 
 pub struct FontRenderer {
     pub font_size: FontSize, // Terminal font-size, not rendered font-size.
@@ -97,6 +98,11 @@ pub fn setup_graphics(
             None
         })
     };
+
+    // Try to detect terminal font
+    if let Ok(terminal_font) = detect_terminal_font() {
+        log::info!("Detected terminal font: {}", terminal_font);
+    }
 
     let font_name = match config_font_family {
         Some(font_family) => font_family.clone(),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -100,13 +100,14 @@ pub fn setup_graphics(
     };
 
     // Try to detect terminal font
-    if let Ok(terminal_font) = detect_terminal_font() {
-        log::info!("Detected terminal font: {}", terminal_font);
+    let terminal_font = detect_terminal_font();
+    if let Ok(terminal_font) = &terminal_font {
+        println!("Detected terminal font: {}", terminal_font);
     }
 
     let font_name = match config_font_family {
         Some(font_family) => font_family.clone(),
-        None => match interactive_font_picker(&mut picker) {
+        None => match interactive_font_picker(&mut picker, terminal_font.ok()) {
             Ok(Some(setup_font_family)) => {
                 config::store_font_family(config, setup_font_family.clone())?;
                 notification::interactive_notification("Font has been written to config file.")?;

--- a/src/setup/fontpicker.rs
+++ b/src/setup/fontpicker.rs
@@ -19,8 +19,11 @@ use crate::{
 };
 
 #[expect(clippy::too_many_lines)]
-pub fn interactive_font_picker(picker: &mut Picker) -> Result<Option<String>, Error> {
-    let mut input = String::new();
+pub fn interactive_font_picker(
+    picker: &mut Picker,
+    terminal_font: Option<String>,
+) -> Result<Option<String>, Error> {
+    let mut input = terminal_font.unwrap_or_default();
 
     let mut font_system = FontSystem::new();
     let swash_cache = SwashCache::new();

--- a/src/setup/fontpicker.rs
+++ b/src/setup/fontpicker.rs
@@ -62,13 +62,14 @@ pub fn interactive_font_picker(
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: ratatui::Viewport::Inline(7),
+            viewport: ratatui::Viewport::Inline(9),
         },
     )?;
     terminal.clear()?;
 
     loop {
-        let first_match = find_first_match(&lowercase_fonts, &input.to_ascii_lowercase());
+        let (first_match, prev_match, next_match) =
+            find_first_match(&lowercase_fonts, &input.to_ascii_lowercase());
 
         terminal.draw(|f| {
             let area = f.area();
@@ -81,21 +82,39 @@ pub fn interactive_font_picker(
             inner_width = inner_area.width;
             f.render_widget(block, area);
 
+            let mut first_line = inner_area;
+            first_line.height = 1;
+            f.render_widget(
+                Paragraph::new(Line::from(prev_match.unwrap_or_default()).dark_gray()),
+                first_line,
+            );
+
+            let mut second_line = inner_area;
+            second_line.y += 1;
+            second_line.height = 1;
             if let Some(first_match) = first_match.clone() {
                 f.render_widget(
                     Paragraph::new(Line::from(first_match).dark_gray()),
-                    inner_area,
+                    second_line,
                 );
             }
             f.render_widget(
                 Paragraph::new(Line::from(input.clone()).white()),
-                inner_area,
+                second_line,
+            );
+
+            let mut third_line = inner_area;
+            third_line.y += 2;
+            third_line.height = 1;
+            f.render_widget(
+                Paragraph::new(Line::from(next_match.unwrap_or_default()).dark_gray()),
+                third_line,
             );
 
             if let Some((_, ref mut proto)) = last_rendered {
                 let img = Image::new(proto);
                 let mut area = inner_area;
-                area.y += 1;
+                area.y += 3;
                 area.height = 2;
                 f.render_widget(img, area);
             }
@@ -105,7 +124,7 @@ pub fn interactive_font_picker(
                 Rect::new(1, f.area().y + f.area().height - 1, inner_area.width, 1),
             );
 
-            f.set_cursor_position(((input.len()) as u16 + 3, f.area().y + 2));
+            f.set_cursor_position(((input.len()) as u16 + 3, f.area().y + 3));
         })?;
 
         if inner_width > 0 && first_match.is_some() {
@@ -145,14 +164,14 @@ pub fn interactive_font_picker(
                         input.pop(); // Remove the last character
                     }
                     KeyCode::Tab => {
-                        if let Some(family) =
+                        if let (Some(family), _, _) =
                             find_first_match(&lowercase_fonts, &input.to_ascii_lowercase())
                         {
                             input = family;
                         }
                     }
                     KeyCode::Enter => {
-                        if let Some(family) =
+                        if let (Some(family), _, _) =
                             find_first_match(&lowercase_fonts, &input.to_ascii_lowercase())
                         {
                             terminal.clear()?;
@@ -172,6 +191,20 @@ pub fn interactive_font_picker(
                         ratatui::restore();
                         return Ok(None);
                     }
+                    KeyCode::Up => {
+                        if let (_, Some(prev), _) =
+                            find_first_match(&lowercase_fonts, &input.to_ascii_lowercase())
+                        {
+                            input = prev;
+                        }
+                    }
+                    KeyCode::Down => {
+                        if let (_, _, Some(next)) =
+                            find_first_match(&lowercase_fonts, &input.to_ascii_lowercase())
+                        {
+                            input = next;
+                        }
+                    }
                     KeyCode::Char(c) => {
                         // Append the character unless a control modifier is pressed
                         if modifiers.is_empty() {
@@ -187,17 +220,25 @@ pub fn interactive_font_picker(
     }
 }
 
-fn find_first_match(all_fonts: &BTreeMap<String, String>, input: &str) -> Option<String> {
-    let mut first_match = None;
+fn find_first_match(
+    all_fonts: &BTreeMap<String, String>,
+    input: &str,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let mut prev = None;
     if input.is_empty() {
-        first_match = all_fonts.first_key_value().map(|t| t.1).cloned();
+        let mut iter = all_fonts.iter();
+        let first_match = iter.next().map(|t| t.1).cloned();
+        let next = iter.next().map(|t| t.1).cloned();
+        return (first_match, None, next);
     } else {
-        for (lowercase_pattern, pattern) in all_fonts {
+        let mut peekable = all_fonts.iter().peekable();
+        for (lowercase_pattern, pattern) in &mut peekable {
             if lowercase_pattern.starts_with(input) {
-                first_match = Some(pattern.clone());
-                break;
+                let next = peekable.peek();
+                return (Some(pattern.clone()), prev, next.map(|t| t.1).cloned());
             }
+            prev = Some(pattern.clone())
         }
     }
-    first_match
+    (None, None, None)
 }

--- a/what-terminal-font/Cargo.toml
+++ b/what-terminal-font/Cargo.toml
@@ -1,78 +1,25 @@
-[workspace]
-members = [ "mdfrier" , "what-terminal-font"]
-
 [package]
-name = "mdfried"
-version = "0.19.2"
+name = "what-terminal-font"
+version = "0.1.0"
 edition = "2024"
 authors = ["Benjamin Große <ste3ls@gmail.com>"]
-description = "A markdown viewer for the terminal that renders images and big headers"
+description = "A crate to detect terminal font"
 repository = "https://github.com/benjajaja/mdfried"
-homepage = "https://github.com/benjajaja/mdfried"
-readme = "README.md"
 license = "GPL-3.0-or-later"
-exclude = ["assets/*"]
 rust-version = "1.86.0"
 
-[features]
-default = ["chafa-dyn"]
-chafa-dyn = ["ratatui-image/chafa-dyn"] # for distribution
-chafa-static = ["ratatui-image/chafa-static"] # for building a static binary with musl
-
 [dependencies]
-bitflags = "2.10.0"
-color-eyre = "0.6.5"
-clap = { version = "4.5.21", features = ["cargo", "derive"] }
-confy = "0.6.1"
-cosmic-text = "0.14.2"
-crossterm = { version = "0.29", features = ["use-dev-tty"] }
-image = "0.25.2"
-itertools = "0.14.0"
-libc = { version = "0.2", default-features = false }
-log = { version = "0.4.28" }
-mdfrier = { version = "0.3.1", path = "mdfrier", features = ["ratatui"] }
-what-terminal-font = { version = "0.1.0", path = "what-terminal-font" }
-notify = "8.1.0"
-notify-debouncer-mini = "0.6.0"
-open = "5.3.3"
-ratatui = { version = "^0.30.0", features = ["serde", "crossterm_0_29"] }
-ratatui-image = { version = "10.0.6", default-features = false, features = ["serde"] }
-regex = "1.11.1"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-unicode-width = "0.2.2"
-serde = { version = "^1.0", features = ["derive"] }
-textwrap = "0.16.2"
-tokio = { version = "1.32.0", features = ["full"] }
-tree-sitter = "0.26"
-tree-sitter-md = "0.5"
-flexi_logger = { version = "0.31.7", features = ["buffer_writer"] }
+thiserror = "1.0"
 
 [dev-dependencies]
-pretty_assertions = "1.4"
-insta = "1.44.3"
-criterion = "0.5.1"
-
-[[bench]]
-name = "full_parse"
-harness = false
 
 [[bin]]
-name = "mdfried"
-bench = false
+name = "what-terminal-font"
+path = "src/main.rs"
 
 [package.metadata.release]
 sign-commit = true
 sign-tag = true
-
-[profile.release]
-codegen-units = 1
-lto = true
-opt-level = 3
-
-[workspace.metadata.release]
-pre-release-replacements = [
-  {file="CHANGELOG.md", search="## \\[Unreleased\\]", replace="## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly=1},
-]
 
 [lints.rust]
 explicit_outlives_requirements = "warn"
@@ -89,9 +36,7 @@ unused_macro_rules = "warn"
 unused_qualifications = "warn"
 
 [lints.clippy]
-# pedantic = { level = "warn", priority = -1 }
 allow_attributes = "warn"
-# as_conversions = "warn"
 as_pointer_underscore = "warn"
 assertions_on_result_states = "warn"
 cfg_not_test = "warn"

--- a/what-terminal-font/Cargo.toml
+++ b/what-terminal-font/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.86.0"
 thiserror = "1.0"
 
 [dev-dependencies]
+tempfile = "3.10"
 
 [[bin]]
 name = "what-terminal-font"

--- a/what-terminal-font/Cargo.toml
+++ b/what-terminal-font/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Benjamin Große <ste3ls@gmail.com>"]
 description = "A crate to detect terminal font"
 repository = "https://github.com/benjajaja/mdfried"
-license = "GPL-3.0-or-later"
+license = "MIT"
 rust-version = "1.86.0"
 
 [dependencies]

--- a/what-terminal-font/LICENSE
+++ b/what-terminal-font/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Benjamin Große
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -14,7 +14,7 @@
 use std::{
     env,
     fs::File,
-    io::{self, BufRead as _, BufReader},
+    io::{self, BufRead as _, BufReader, Read},
     process::Command,
     string::FromUtf8Error,
 };
@@ -89,12 +89,7 @@ fn detect_with_term_program(
                 return Ok("JetBrainsMono Nerd Font".to_owned());
             }
             "WezTerm" => {
-                let stdout = command_get_stdout(
-                    Command::new("wezterm")
-                        .arg("ls-fonts")
-                        .arg("--text")
-                        .arg("a"),
-                )?;
+                let stdout = config.wezterm()?;
                 if let Some(font) = stdout.split('"').nth(1)
                     && !font.is_empty()
                 {
@@ -129,7 +124,8 @@ fn detect_with_term(
         match term.as_str() {
             "xterm-kitty" => stdout_get_line("kitty", config.kitty()?, "font_family: "),
             "foot" => {
-                let line = config_get_line("foot/foot.ini", "font=")?;
+                let reader = config.foot()?;
+                let line = reader_get_line("foot", reader, "font=")?;
                 if let Some(font_family) = line.split(':').next()
                     && !font_family.is_empty()
                 {
@@ -150,6 +146,8 @@ trait TerminalConfig {
     fn ghostty(&self) -> Result<String, WtfError>;
     fn kitty(&self) -> Result<String, WtfError>;
     fn rio(&self) -> Result<BufReader<File>, WtfError>;
+    fn wezterm(&self) -> Result<String, WtfError>;
+    fn foot(&self) -> Result<BufReader<File>, WtfError>;
 }
 
 struct RealTerminal;
@@ -166,6 +164,19 @@ impl TerminalConfig for RealTerminal {
     fn rio(&self) -> Result<BufReader<File>, WtfError> {
         config_get_reader("rio/config.toml")
     }
+
+    fn wezterm(&self) -> Result<String, WtfError> {
+        command_get_stdout(
+            Command::new("wezterm")
+                .arg("ls-fonts")
+                .arg("--text")
+                .arg("a"),
+        )
+    }
+
+    fn foot(&self) -> Result<BufReader<File>, WtfError> {
+        config_get_reader("foot/foot.ini")
+    }
 }
 
 fn config_get_reader(config_file: &'static str) -> Result<BufReader<File>, WtfError> {
@@ -178,30 +189,6 @@ fn config_get_reader(config_file: &'static str) -> Result<BufReader<File>, WtfEr
     let path = format!("{}/{}", config_home, config_file);
 
     Ok(BufReader::new(File::open(path)?))
-}
-
-fn config_get_line(
-    config_file: &'static str,
-    line_prefix: &'static str,
-) -> Result<String, WtfError> {
-    let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
-        format!(
-            "{}/.config",
-            env::var("HOME").unwrap_or_else(|_| "~".to_owned())
-        )
-    });
-    let path = format!("{}/{}", config_home, config_file);
-
-    let reader = BufReader::new(File::open(path)?);
-    for line in reader.lines() {
-        let line = line?;
-        if line.starts_with(line_prefix)
-            && let Some(font_family_line) = line.get(line_prefix.len()..)
-        {
-            return Ok(font_family_line.to_owned());
-        }
-    }
-    Err(WtfError::ConfigFile(config_file, line_prefix))
 }
 
 fn reader_get_line(

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -87,6 +87,7 @@ fn detect_with_term_program(
                 if let Ok(font) = stdout_get_line("ghostty", stdout, "font-family = ") {
                     return Ok(font);
                 }
+                // Default font of ghostty
                 return Ok("JetBrainsMono Nerd Font".to_owned());
             }
             "WezTerm" => {
@@ -102,13 +103,15 @@ fn detect_with_term_program(
                 }
             }
             "rio" => {
-                let reader = config.rio()?;
-                if let Ok(line) = reader_get_line("rio", reader, "family = \"")
-                    && let Some(font_family) = line.split('"').next()
-                    && !font_family.is_empty()
-                {
-                    return Ok(font_family.to_owned());
+                if let Ok(reader) = config.rio() {
+                    if let Ok(line) = reader_get_line("rio", reader, "family = \"")
+                        && let Some(font_family) = line.split('"').next()
+                        && !font_family.is_empty()
+                    {
+                        return Ok(font_family.to_owned());
+                    }
                 }
+                // Default font of rio
                 return Ok("Cascadia Code".to_owned());
             }
             _ => {}
@@ -123,31 +126,34 @@ fn detect_with_term(
 ) -> Result<String, WtfError> {
     if let Ok(term) = var {
         match term.as_str() {
-            "xterm-kitty" => stdout_get_line("kitty", config.kitty()?, "font_family: "),
+            "xterm-kitty" => {
+                return stdout_get_line("kitty", config.kitty()?, "font_family: ");
+            }
             "foot" => {
-                let reader = config.foot()?;
-                let line = reader_get_line("foot", reader, "font=")?;
-                if let Some(font_family) = line.split(':').next()
-                    && !font_family.is_empty()
-                {
-                    return Ok(font_family.to_owned());
+                if let Ok(reader) = config.foot() {
+                    let line = reader_get_line("foot", reader, "font=")?;
+                    if let Some(font_family) = line.split(':').next()
+                        && !font_family.is_empty()
+                    {
+                        return Ok(font_family.to_owned());
+                    }
                 }
-                Err(WtfError::FontNotFound(
-                    "foot config expected font line to contain colon separating font-family and size",
-                ))
+                Err(WtfError::FontNotFound("foot"))
             }
             "xterm" | "xterm-256color" => {
-                let reader = config.xterm()?;
-                let font_line = reader_get_line("xterm", reader, "xterm*faceName:")?;
-                if !font_line.is_empty() {
-                    return Ok(font_line);
+                if let Ok(reader) = config.xterm() {
+                    let font_line = reader_get_line("xterm", reader, "xterm*faceName:")?;
+                    if !font_line.is_empty() {
+                        return Ok(font_line);
+                    }
+                    let reader = config.xterm()?;
+                    let font_line = reader_get_line("xterm", reader, "xterm.vt100.faceName:")?;
+                    if !font_line.is_empty() {
+                        return Ok(font_line);
+                    }
                 }
-                let reader = config.xterm()?;
-                let font_line = reader_get_line("xterm", reader, "xterm.vt100.faceName:")?;
-                if !font_line.is_empty() {
-                    return Ok(font_line);
-                }
-                // "fixed" is the standard X11 built-in monospace font, used as fallback
+                // "fixed" is the standard X11 built-in monospace font, used as fallback in
+                // fastfetch
                 Ok("fixed".to_owned())
             }
             _ => Err(WtfError::UnknownTerminal),

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -8,6 +8,7 @@
 //! * foot
 //! * wezterm
 //! * rio
+//! * xterm
 //!
 //! Inspired by fastfetch (and clones') font detection: https://github.com/fastfetch-cli/fastfetch
 
@@ -135,6 +136,20 @@ fn detect_with_term(
                     "foot config expected font line to contain colon separating font-family and size",
                 ))
             }
+            "xterm" | "xterm-256color" => {
+                let reader = config.xterm()?;
+                let font_line = reader_get_line("xterm", reader, "xterm*faceName:")?;
+                if !font_line.is_empty() {
+                    return Ok(font_line);
+                }
+                let reader = config.xterm()?;
+                let font_line = reader_get_line("xterm", reader, "xterm.vt100.faceName:")?;
+                if !font_line.is_empty() {
+                    return Ok(font_line);
+                }
+                // "fixed" is the standard X11 built-in monospace font, used as fallback
+                Ok("fixed".to_owned())
+            }
             _ => Err(WtfError::UnknownTerminal),
         }
     } else {
@@ -148,6 +163,7 @@ trait TerminalConfig {
     fn rio(&self) -> Result<BufReader<File>, WtfError>;
     fn wezterm(&self) -> Result<String, WtfError>;
     fn foot(&self) -> Result<BufReader<File>, WtfError>;
+    fn xterm(&self) -> Result<BufReader<File>, WtfError>;
 }
 
 struct RealTerminal;
@@ -176,6 +192,10 @@ impl TerminalConfig for RealTerminal {
 
     fn foot(&self) -> Result<BufReader<File>, WtfError> {
         config_get_reader("foot/foot.ini")
+    }
+
+    fn xterm(&self) -> Result<BufReader<File>, WtfError> {
+        config_get_reader(".Xresources")
     }
 }
 

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -21,18 +21,26 @@ use std::{
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum Error {
+pub enum WtfError {
     #[error("Terminal could not be determined or is unsupported")]
     UnknownTerminal,
     #[error("Font could not be detected")]
     FontNotFound,
     #[error("I/O Error")]
     Io(io::Error),
+    #[error("Env Var Error")]
+    EnvVar(env::VarError),
 }
 
-impl From<io::Error> for Error {
+impl From<io::Error> for WtfError {
     fn from(value: io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+impl From<env::VarError> for WtfError {
+    fn from(value: env::VarError) -> Self {
+        Self::EnvVar(value)
     }
 }
 
@@ -44,7 +52,7 @@ impl From<io::Error> for Error {
 ///     Err(e) => eprintln!("Error detecting font: {}", e),
 /// }
 /// ```
-pub fn detect_terminal_font() -> Result<String, Error> {
+pub fn detect_terminal_font() -> Result<String, WtfError> {
     if let Ok(term_program) = env::var("TERM_PROGRAM") {
         match term_program.as_str() {
             "ghostty" => {
@@ -57,7 +65,7 @@ pub fn detect_terminal_font() -> Result<String, Error> {
                     if line.starts_with(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX)
                         && let Some(font_family) =
                             line.get(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && font_family.len() > 0
+                        && !font_family.is_empty()
                     {
                         return Ok(font_family.to_owned());
                     }
@@ -73,16 +81,20 @@ pub fn detect_terminal_font() -> Result<String, Error> {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let font = stdout.split('"').nth(1);
                 if let Some(font) = font
-                    && font.len() > 0
+                    && !font.is_empty()
                 {
                     return Ok(font.to_owned());
                 }
-                return Err(Error::FontNotFound);
+                return Err(WtfError::FontNotFound);
             }
             "rio" => {
                 const RIO_FONT_FAMILY_CONFIG_PREFIX: &str = "family = \"";
-                let config_home = env::var("XDG_CONFIG_HOME")
-                    .unwrap_or_else(|_| format!("{}/.config", env::var("HOME").unwrap()));
+                let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+                    format!(
+                        "{}/.config",
+                        env::var("HOME").unwrap_or_else(|_| "~".to_owned())
+                    )
+                });
 
                 let path = format!("{}/rio/config.toml", config_home);
                 let reader = BufReader::new(File::open(path)?);
@@ -91,15 +103,13 @@ pub fn detect_terminal_font() -> Result<String, Error> {
                     if line.starts_with(RIO_FONT_FAMILY_CONFIG_PREFIX)
                         && let Some(font_family_line) =
                             line.get(RIO_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                        && let Some(font_family) = font_family_line.split('"').nth(1)
+                        && !font_family.is_empty()
                     {
-                        if let Some(font_family) = font_family_line.split('"').nth(1)
-                            && font_family.len() > 0
-                        {
-                            return Ok(font_family.to_owned());
-                        }
+                        return Ok(font_family.to_owned());
                     }
                 }
-                return Err(Error::FontNotFound);
+                return Err(WtfError::FontNotFound);
             }
             _ => {}
         }
@@ -113,17 +123,21 @@ pub fn detect_terminal_font() -> Result<String, Error> {
                 for line in stdout.lines() {
                     if line.starts_with(KITTY_FONT_FAMILY_CONFIG_PREFIX)
                         && let Some(font_family) = line.get(KITTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && font_family.len() > 0
+                        && !font_family.is_empty()
                     {
                         return Ok(font_family.to_owned());
                     }
                 }
-                return Err(Error::FontNotFound);
+                return Err(WtfError::FontNotFound);
             }
             "foot" => {
                 const FOOT_FONT_FAMILY_CONFIG_PREFIX: &str = "font=";
-                let config_home = env::var("XDG_CONFIG_HOME")
-                    .unwrap_or_else(|_| format!("{}/.config", env::var("HOME").unwrap()));
+                let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+                    format!(
+                        "{}/.config",
+                        env::var("HOME").unwrap_or_else(|_| "~".to_owned())
+                    )
+                });
 
                 let path = format!("{}/foot/foot.ini", config_home);
                 let reader = BufReader::new(File::open(path)?);
@@ -131,18 +145,16 @@ pub fn detect_terminal_font() -> Result<String, Error> {
                     let line = line?;
                     if line.starts_with(FOOT_FONT_FAMILY_CONFIG_PREFIX)
                         && let Some(font_family) = line.get(FOOT_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                        && let Some(first) = font_family.split(":").next()
+                        && !first.is_empty()
                     {
-                        if let Some(first) = font_family.split(":").nth(0)
-                            && first.len() > 0
-                        {
-                            return Ok(first.to_owned());
-                        }
+                        return Ok(first.to_owned());
                     }
                 }
-                return Err(Error::FontNotFound);
+                return Err(WtfError::FontNotFound);
             }
             _ => {}
         }
     }
-    Err(Error::UnknownTerminal)
+    Err(WtfError::UnknownTerminal)
 }

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -1,21 +1,45 @@
-//! what-terminal-font - Detect the terminal font in use, for at least some popular terminals.
+//! # what-terminal-font
 //!
-//! This crate provides functionality to detect what font is currently being used
-//! by the terminal, if the terminal is one of:
+//! Detect the terminal font in use, at least for some popular terminals.
 //!
-//! * kitty
-//! * ghostty
-//! * foot
-//! * wezterm
-//! * rio
-//! * xterm
+//! Inspired by [fastfetch]. Used by [mdfried].
 //!
-//! Inspired by fastfetch (and clones') font detection: https://github.com/fastfetch-cli/fastfetch
+//! This crate attempts to detect what font is currently being used by the terminal, if the
+//! terminal has an implementation in this crate, and either a font is configured, or the terminal
+//! has some mechanism for querying the font via some command, or there is a known default font.
+//!
+//! **Note: the returned "font family" string might not necessarily match the font family
+//! name exactly as reported by the different font systems elsewhere.**
+//!
+//! # Implementations
+//!
+//! * [x] `ghostty, kitty, wezterm` are queried via some command, and the output is parsed.
+//! * [x] `foot, rio, xterm` use their configuration files (linux specific).
+//! * [ ] konsole: doesn't set any `$TERM`-like env var, but config should be parseable.
+//! * [ ] iterm2: macos hardware.
+//! * [ ] others: PRs welcome, [fastfetch source] is a good reference.
+//!
+//! # Example
+//!
+//! ```rust
+//! use what_terminal_font::{detect_terminal_font, WtfError};
+//!
+//! match detect_terminal_font() {
+//!     Ok(font) => println!("Using font: {}", font),
+//!     Err(WtfError::FontNotFound(err)) => println!("Font not detected ({err}), falling back to 'monospace'."),
+//!     Err(WtfError::UnknownTerminal) => println!("Unknown terminal, falling back to 'monospace'."),
+//!     Err(WtfError::Io(err)) => println!("{err}, aborting."),
+//! }
+//! ```
+//!
+//! [fastfetch]: https://github.com/fastfetch-cli/fastfetch
+//! [mdfried]: https://crates.io/crates/mdfried
+//! [fastfetch source]: https://github.com/fastfetch-cli/fastfetch/blob/master/src/detection/terminalfont/terminalfont_linux.c
 
 use std::{
     env,
     fs::File,
-    io::{self, BufRead as _, BufReader},
+    io::{self, BufRead, BufReader},
     process::Command,
     string::FromUtf8Error,
 };
@@ -24,18 +48,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum WtfError {
+    #[error("I/O Error")]
+    Io(io::Error),
     #[error("Terminal could not be determined or is unsupported")]
     UnknownTerminal,
     #[error("Font could not be detected: {0}")]
     FontNotFound(&'static str),
-    #[error("I/O Error")]
-    Io(io::Error),
-    #[error("Env Var Error")]
-    EnvVar(env::VarError),
-    #[error("Config file {0} expected line with prefix '{1}'")]
-    ConfigFile(&'static str, &'static str),
-    #[error("{0} output expected line with prefix '{1}'")]
-    CommandOutput(&'static str, &'static str),
 }
 
 impl From<io::Error> for WtfError {
@@ -46,7 +64,7 @@ impl From<io::Error> for WtfError {
 
 impl From<env::VarError> for WtfError {
     fn from(value: env::VarError) -> Self {
-        Self::EnvVar(value)
+        Self::Io(io::Error::other(value))
     }
 }
 
@@ -58,12 +76,12 @@ impl From<FromUtf8Error> for WtfError {
 
 /// Try to detect the terminal font name.
 ///
-/// ```rust
-/// match what_terminal_font::detect_terminal_font() {
-///     Ok(font) => println!("Using font: {}", font),
-///     Err(e) => println!("Error detecting font: {}", e),
-/// }
-/// ```
+/// Gets the font name by config file or command.
+/// If there is a known fallback when the font is not configure, it will be returned. Otherwise
+/// [`WtfError::FontNotFound`] will be returned.
+///
+/// If there is no implementation for the current terminal, then [`WtfError::UnknownTerminal`] will
+/// be returned.
 pub fn detect_terminal_font() -> Result<String, WtfError> {
     detect(RealTerminal, env::var("TERM_PROGRAM"), env::var("TERM"))
 }
@@ -84,7 +102,11 @@ fn detect_with_term_program(
         match term_program.as_str() {
             "ghostty" => {
                 let stdout = config.ghostty()?;
-                if let Ok(font) = stdout_get_line("ghostty", stdout, "font-family = ") {
+                if let Ok(font) = find_line(
+                    stdout.as_bytes(),
+                    "font-family = ",
+                    "ghostty output had no font-family",
+                ) {
                     return Ok(font);
                 }
                 // Default font of ghostty
@@ -104,7 +126,7 @@ fn detect_with_term_program(
             }
             "rio" => {
                 if let Ok(reader) = config.rio() {
-                    if let Ok(line) = reader_get_line("rio", reader, "family = \"")
+                    if let Ok(line) = find_line(reader, "family = \"", "rio config had no family")
                         && let Some(font_family) = line.split('"').next()
                         && !font_family.is_empty()
                     {
@@ -126,12 +148,14 @@ fn detect_with_term(
 ) -> Result<String, WtfError> {
     if let Ok(term) = var {
         match term.as_str() {
-            "xterm-kitty" => {
-                return stdout_get_line("kitty", config.kitty()?, "font_family: ");
-            }
+            "xterm-kitty" => find_line(
+                config.kitty()?.as_bytes(),
+                "font_family: ",
+                "kitten output had no font_family",
+            ),
             "foot" => {
                 if let Ok(reader) = config.foot() {
-                    let line = reader_get_line("foot", reader, "font=")?;
+                    let line = find_line(reader, "font=", "foot config had not font")?;
                     if let Some(font_family) = line.split(':').next()
                         && !font_family.is_empty()
                     {
@@ -142,15 +166,18 @@ fn detect_with_term(
             }
             "xterm" | "xterm-256color" => {
                 if let Ok(reader) = config.xterm() {
-                    let font_line = reader_get_line("xterm", reader, "xterm*faceName:")?;
-                    if !font_line.is_empty() {
+                    if let Ok(font_line) = find_line(reader, "xterm*faceName:", "xterm*faceName")
+                        && !font_line.is_empty()
+                    {
                         return Ok(font_line);
                     }
-                    let reader = config.xterm()?;
-                    let font_line = reader_get_line("xterm", reader, "xterm.vt100.faceName:")?;
-                    if !font_line.is_empty() {
-                        return Ok(font_line);
-                    }
+                }
+                if let Ok(reader) = config.xterm()
+                    && let Ok(font_line) =
+                        find_line(reader, "xterm.vt100.faceName:", "xterm.vt100.faceName")
+                    && !font_line.is_empty()
+                {
+                    return Ok(font_line);
                 }
                 // "fixed" is the standard X11 built-in monospace font, used as fallback in
                 // fastfetch
@@ -217,28 +244,19 @@ fn config_get_reader(config_file: &'static str) -> Result<BufReader<File>, WtfEr
     Ok(BufReader::new(File::open(path)?))
 }
 
-fn reader_get_line(
-    terminal: &'static str,
-    reader: BufReader<File>,
-    line_prefix: &'static str,
-) -> Result<String, WtfError> {
-    for line in reader.lines() {
-        let line = line?;
-        if line.starts_with(line_prefix)
-            && let Some(font_family_line) = line.get(line_prefix.len()..)
-        {
-            return Ok(font_family_line.to_owned());
-        }
-    }
-    Err(WtfError::ConfigFile(terminal, line_prefix))
+fn command_get_stdout(cmd: &mut Command) -> Result<String, WtfError> {
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(stdout)
 }
 
-fn stdout_get_line(
-    terminal: &'static str,
-    stdout: String,
+fn find_line(
+    source: impl BufRead,
     prefix: &'static str,
+    error_message: &'static str,
 ) -> Result<String, WtfError> {
-    for line in stdout.lines() {
+    for line in source.lines() {
+        let line = line?;
         if line.starts_with(prefix)
             && let Some(font_family) = line.get(prefix.len()..)
             && !font_family.is_empty()
@@ -246,13 +264,7 @@ fn stdout_get_line(
             return Ok(font_family.to_owned());
         }
     }
-    Err(WtfError::CommandOutput(terminal, prefix))
-}
-
-fn command_get_stdout(cmd: &mut Command) -> Result<String, WtfError> {
-    let output = cmd.output()?;
-    let stdout = String::from_utf8(output.stdout)?;
-    Ok(stdout)
+    Err(WtfError::FontNotFound(error_message))
 }
 
 #[cfg(test)]

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -14,7 +14,7 @@
 use std::{
     env,
     fs::File,
-    io::{self, BufRead as _, BufReader, Read},
+    io::{self, BufRead as _, BufReader},
     process::Command,
     string::FromUtf8Error,
 };
@@ -60,7 +60,7 @@ impl From<FromUtf8Error> for WtfError {
 /// ```rust
 /// match what_terminal_font::detect_terminal_font() {
 ///     Ok(font) => println!("Using font: {}", font),
-///     Err(e) => eprintln!("Error detecting font: {}", e),
+///     Err(e) => println!("Error detecting font: {}", e),
 /// }
 /// ```
 pub fn detect_terminal_font() -> Result<String, WtfError> {

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
     fs::File,
     io::{self, BufRead as _, BufReader},
     process::Command,
+    string::FromUtf8Error,
 };
 
 use thiserror::Error;
@@ -24,12 +25,16 @@ use thiserror::Error;
 pub enum WtfError {
     #[error("Terminal could not be determined or is unsupported")]
     UnknownTerminal,
-    #[error("Font could not be detected")]
-    FontNotFound,
+    #[error("Font could not be detected: {0}")]
+    FontNotFound(&'static str),
     #[error("I/O Error")]
     Io(io::Error),
     #[error("Env Var Error")]
     EnvVar(env::VarError),
+    #[error("Config file {0} expected line with prefix '{1}'")]
+    ConfigFile(&'static str, &'static str),
+    #[error("Command {0} {1:?} expected line with prefix '{2}'")]
+    CommandOutput(String, Vec<String>, &'static str),
 }
 
 impl From<io::Error> for WtfError {
@@ -41,6 +46,12 @@ impl From<io::Error> for WtfError {
 impl From<env::VarError> for WtfError {
     fn from(value: env::VarError) -> Self {
         Self::EnvVar(value)
+    }
+}
+
+impl From<FromUtf8Error> for WtfError {
+    fn from(value: FromUtf8Error) -> Self {
+        Self::Io(io::Error::other(value))
     }
 }
 
@@ -56,60 +67,40 @@ pub fn detect_terminal_font() -> Result<String, WtfError> {
     if let Ok(term_program) = env::var("TERM_PROGRAM") {
         match term_program.as_str() {
             "ghostty" => {
-                const GHOSTTY_DEFAULT_FONT: &str = "JetBrainsMono Nerd Font";
-                const GHOSTTY_FONT_FAMILY_CONFIG_PREFIX: &str = "font-family = ";
-
-                let output = Command::new("ghostty").arg("+show-config").output()?;
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                for line in stdout.lines() {
-                    if line.starts_with(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX)
-                        && let Some(font_family) =
-                            line.get(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && !font_family.is_empty()
-                    {
-                        return Ok(font_family.to_owned());
-                    }
+                if let Ok(font) = command_get_line(
+                    Command::new("ghostty").arg("+show-config"),
+                    "font-family = ",
+                ) {
+                    return Ok(font);
+                } else {
+                    return Ok("JetBrainsMono Nerd Font".to_owned());
                 }
-                return Ok(GHOSTTY_DEFAULT_FONT.to_owned());
             }
             "WezTerm" => {
-                let output = Command::new("wezterm")
-                    .arg("ls-fonts")
-                    .arg("--text")
-                    .arg("a")
-                    .output()?;
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let font = stdout.split('"').nth(1);
-                if let Some(font) = font
+                let stdout = command_get_stdout(
+                    Command::new("wezterm")
+                        .arg("ls-fonts")
+                        .arg("--text")
+                        .arg("a"),
+                )?;
+                if let Some(font) = stdout.split('"').nth(1)
                     && !font.is_empty()
                 {
                     return Ok(font.to_owned());
+                } else {
+                    return Err(WtfError::FontNotFound(
+                        "wezterm command had unexpected output",
+                    ));
                 }
-                return Err(WtfError::FontNotFound);
             }
             "rio" => {
-                const RIO_FONT_FAMILY_CONFIG_PREFIX: &str = "family = \"";
-                let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
-                    format!(
-                        "{}/.config",
-                        env::var("HOME").unwrap_or_else(|_| "~".to_owned())
-                    )
-                });
-
-                let path = format!("{}/rio/config.toml", config_home);
-                let reader = BufReader::new(File::open(path)?);
-                for line in reader.lines() {
-                    let line = line?;
-                    if line.starts_with(RIO_FONT_FAMILY_CONFIG_PREFIX)
-                        && let Some(font_family_line) =
-                            line.get(RIO_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && let Some(font_family) = font_family_line.split('"').nth(1)
-                        && !font_family.is_empty()
-                    {
-                        return Ok(font_family.to_owned());
-                    }
+                if let Ok(line) = config_get_line("rio/config.toml", "family = \"")
+                    && let Some(font_family) = line.split('"').next()
+                    && !font_family.is_empty()
+                {
+                    return Ok(font_family.to_owned());
                 }
-                return Err(WtfError::FontNotFound);
+                return Ok("Cascadia Code".to_owned());
             }
             _ => {}
         }
@@ -117,44 +108,73 @@ pub fn detect_terminal_font() -> Result<String, WtfError> {
     if let Ok(term) = env::var("TERM") {
         match term.as_str() {
             "xterm-kitty" => {
-                const KITTY_FONT_FAMILY_CONFIG_PREFIX: &str = "font_family: ";
-                let output = Command::new("kitten").arg("query-terminal").output()?;
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                for line in stdout.lines() {
-                    if line.starts_with(KITTY_FONT_FAMILY_CONFIG_PREFIX)
-                        && let Some(font_family) = line.get(KITTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && !font_family.is_empty()
-                    {
-                        return Ok(font_family.to_owned());
-                    }
-                }
-                return Err(WtfError::FontNotFound);
+                return command_get_line(
+                    Command::new("kitten").arg("query-terminal"),
+                    "font_family: ",
+                );
             }
             "foot" => {
-                const FOOT_FONT_FAMILY_CONFIG_PREFIX: &str = "font=";
-                let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
-                    format!(
-                        "{}/.config",
-                        env::var("HOME").unwrap_or_else(|_| "~".to_owned())
-                    )
-                });
-
-                let path = format!("{}/foot/foot.ini", config_home);
-                let reader = BufReader::new(File::open(path)?);
-                for line in reader.lines() {
-                    let line = line?;
-                    if line.starts_with(FOOT_FONT_FAMILY_CONFIG_PREFIX)
-                        && let Some(font_family) = line.get(FOOT_FONT_FAMILY_CONFIG_PREFIX.len()..)
-                        && let Some(first) = font_family.split(":").next()
-                        && !first.is_empty()
-                    {
-                        return Ok(first.to_owned());
-                    }
+                let line = config_get_line("foot/foot.ini", "font=")?;
+                if let Some(font_family) = line.split(':').next()
+                    && !font_family.is_empty()
+                {
+                    return Ok(font_family.to_owned());
                 }
-                return Err(WtfError::FontNotFound);
+                return Err(WtfError::FontNotFound(
+                    "foot config expected font line to contain colon separating font-family and size",
+                ));
             }
             _ => {}
         }
     }
     Err(WtfError::UnknownTerminal)
+}
+
+fn config_get_line(
+    config_file: &'static str,
+    line_prefix: &'static str,
+) -> Result<String, WtfError> {
+    let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        format!(
+            "{}/.config",
+            env::var("HOME").unwrap_or_else(|_| "~".to_owned())
+        )
+    });
+    let path = format!("{}/{}", config_home, config_file);
+
+    let reader = BufReader::new(File::open(path)?);
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with(line_prefix)
+            && let Some(font_family_line) = line.get(line_prefix.len()..)
+        {
+            return Ok(font_family_line.to_owned());
+        }
+    }
+    Err(WtfError::ConfigFile(config_file, line_prefix))
+}
+
+fn command_get_line(cmd: &mut Command, prefix: &'static str) -> Result<String, WtfError> {
+    let stdout = command_get_stdout(cmd)?;
+    for line in stdout.lines() {
+        if line.starts_with(prefix)
+            && let Some(font_family) = line.get(prefix.len()..)
+            && !font_family.is_empty()
+        {
+            return Ok(font_family.to_owned());
+        }
+    }
+    Err(WtfError::CommandOutput(
+        cmd.get_program().to_str().unwrap_or("[missing]").to_owned(),
+        cmd.get_args()
+            .map(|arg| arg.to_str().unwrap_or("[missing]").to_owned())
+            .collect(),
+        prefix,
+    ))
+}
+
+fn command_get_stdout(cmd: &mut Command) -> Result<String, WtfError> {
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(stdout)
 }

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -1,0 +1,148 @@
+//! what-terminal-font - Detect the terminal font in use, for at least some popular terminals.
+//!
+//! This crate provides functionality to detect what font is currently being used
+//! by the terminal, if the terminal is one of:
+//!
+//! * kitty
+//! * ghostty
+//! * foot
+//! * wezterm
+//! * rio
+//!
+//! Inspired by fastfetch (and clones') font detection: https://github.com/fastfetch-cli/fastfetch
+
+use std::{
+    env,
+    fs::File,
+    io::{self, BufRead as _, BufReader},
+    process::Command,
+};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Terminal could not be determined or is unsupported")]
+    UnknownTerminal,
+    #[error("Font could not be detected")]
+    FontNotFound,
+    #[error("I/O Error")]
+    Io(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// Try to detect the terminal font name.
+///
+/// ```rust
+/// match what_terminal_font::get_terminal_font() {
+///     Ok(font) => println!("Using font: {}", font),
+///     Err(e) => eprintln!("Error detecting font: {}", e),
+/// }
+/// ```
+pub fn detect_terminal_font() -> Result<String, Error> {
+    if let Ok(term_program) = env::var("TERM_PROGRAM") {
+        match term_program.as_str() {
+            "ghostty" => {
+                const GHOSTTY_DEFAULT_FONT: &str = "JetBrainsMono Nerd Font";
+                const GHOSTTY_FONT_FAMILY_CONFIG_PREFIX: &str = "font-family = ";
+
+                let output = Command::new("ghostty").arg("+show-config").output()?;
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if line.starts_with(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX)
+                        && let Some(font_family) =
+                            line.get(GHOSTTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                        && font_family.len() > 0
+                    {
+                        return Ok(font_family.to_owned());
+                    }
+                }
+                return Ok(GHOSTTY_DEFAULT_FONT.to_owned());
+            }
+            "WezTerm" => {
+                let output = Command::new("wezterm")
+                    .arg("ls-fonts")
+                    .arg("--text")
+                    .arg("a")
+                    .output()?;
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let font = stdout.split('"').nth(1);
+                if let Some(font) = font
+                    && font.len() > 0
+                {
+                    return Ok(font.to_owned());
+                }
+                return Err(Error::FontNotFound);
+            }
+            "rio" => {
+                const RIO_FONT_FAMILY_CONFIG_PREFIX: &str = "family = \"";
+                let config_home = env::var("XDG_CONFIG_HOME")
+                    .unwrap_or_else(|_| format!("{}/.config", env::var("HOME").unwrap()));
+
+                let path = format!("{}/rio/config.toml", config_home);
+                let reader = BufReader::new(File::open(path)?);
+                for line in reader.lines() {
+                    let line = line?;
+                    if line.starts_with(RIO_FONT_FAMILY_CONFIG_PREFIX)
+                        && let Some(font_family_line) =
+                            line.get(RIO_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                    {
+                        if let Some(font_family) = font_family_line.split('"').nth(1)
+                            && font_family.len() > 0
+                        {
+                            return Ok(font_family.to_owned());
+                        }
+                    }
+                }
+                return Err(Error::FontNotFound);
+            }
+            _ => {}
+        }
+    }
+    if let Ok(term) = env::var("TERM") {
+        match term.as_str() {
+            "xterm-kitty" => {
+                const KITTY_FONT_FAMILY_CONFIG_PREFIX: &str = "font_family: ";
+                let output = Command::new("kitten").arg("query-terminal").output()?;
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if line.starts_with(KITTY_FONT_FAMILY_CONFIG_PREFIX)
+                        && let Some(font_family) = line.get(KITTY_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                        && font_family.len() > 0
+                    {
+                        return Ok(font_family.to_owned());
+                    }
+                }
+                return Err(Error::FontNotFound);
+            }
+            "foot" => {
+                const FOOT_FONT_FAMILY_CONFIG_PREFIX: &str = "font=";
+                let config_home = env::var("XDG_CONFIG_HOME")
+                    .unwrap_or_else(|_| format!("{}/.config", env::var("HOME").unwrap()));
+
+                let path = format!("{}/foot/foot.ini", config_home);
+                let reader = BufReader::new(File::open(path)?);
+                for line in reader.lines() {
+                    let line = line?;
+                    if line.starts_with(FOOT_FONT_FAMILY_CONFIG_PREFIX)
+                        && let Some(font_family) = line.get(FOOT_FONT_FAMILY_CONFIG_PREFIX.len()..)
+                    {
+                        if let Some(first) = font_family.split(":").nth(0)
+                            && first.len() > 0
+                        {
+                            return Ok(first.to_owned());
+                        }
+                    }
+                }
+                return Err(Error::FontNotFound);
+            }
+            _ => {}
+        }
+    }
+    Err(Error::UnknownTerminal)
+}

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -33,8 +33,8 @@ pub enum WtfError {
     EnvVar(env::VarError),
     #[error("Config file {0} expected line with prefix '{1}'")]
     ConfigFile(&'static str, &'static str),
-    #[error("Command {0} {1:?} expected line with prefix '{2}'")]
-    CommandOutput(String, Vec<String>, &'static str),
+    #[error("{0} output expected line with prefix '{1}'")]
+    CommandOutput(&'static str, &'static str),
 }
 
 impl From<io::Error> for WtfError {
@@ -58,23 +58,29 @@ impl From<FromUtf8Error> for WtfError {
 /// Try to detect the terminal font name.
 ///
 /// ```rust
-/// match what_terminal_font::get_terminal_font() {
+/// match what_terminal_font::detect_terminal_font() {
 ///     Ok(font) => println!("Using font: {}", font),
 ///     Err(e) => eprintln!("Error detecting font: {}", e),
 /// }
 /// ```
 pub fn detect_terminal_font() -> Result<String, WtfError> {
-    if let Ok(term_program) = env::var("TERM_PROGRAM") {
+    let config = RealTerminal {};
+    detect_with_term_program(env::var("TERM_PROGRAM"), &config)
+        .or(detect_with_term(env::var("TERM"), &config))
+}
+
+fn detect_with_term_program(
+    var: Result<String, env::VarError>,
+    config: &impl TerminalConfig,
+) -> Result<String, WtfError> {
+    if let Ok(term_program) = var {
         match term_program.as_str() {
             "ghostty" => {
-                if let Ok(font) = command_get_line(
-                    Command::new("ghostty").arg("+show-config"),
-                    "font-family = ",
-                ) {
+                let stdout = config.ghostty()?;
+                if let Ok(font) = stdout_get_line("ghostty", stdout, "font-family = ") {
                     return Ok(font);
-                } else {
-                    return Ok("JetBrainsMono Nerd Font".to_owned());
                 }
+                return Ok("JetBrainsMono Nerd Font".to_owned());
             }
             "WezTerm" => {
                 let stdout = command_get_stdout(
@@ -94,7 +100,8 @@ pub fn detect_terminal_font() -> Result<String, WtfError> {
                 }
             }
             "rio" => {
-                if let Ok(line) = config_get_line("rio/config.toml", "family = \"")
+                let reader = config.rio()?;
+                if let Ok(line) = reader_get_line("rio", reader, "family = \"")
                     && let Some(font_family) = line.split('"').next()
                     && !font_family.is_empty()
                 {
@@ -105,10 +112,18 @@ pub fn detect_terminal_font() -> Result<String, WtfError> {
             _ => {}
         }
     }
-    if let Ok(term) = env::var("TERM") {
+    Err(WtfError::UnknownTerminal)
+}
+
+fn detect_with_term(
+    var: Result<String, env::VarError>,
+    config: &impl TerminalConfig,
+) -> Result<String, WtfError> {
+    if let Ok(term) = var {
         match term.as_str() {
             "xterm-kitty" => {
                 return command_get_line(
+                    "kitty",
                     Command::new("kitten").arg("query-terminal"),
                     "font_family: ",
                 );
@@ -128,6 +143,35 @@ pub fn detect_terminal_font() -> Result<String, WtfError> {
         }
     }
     Err(WtfError::UnknownTerminal)
+}
+
+trait TerminalConfig {
+    fn ghostty(&self) -> Result<String, WtfError>;
+    fn rio(&self) -> Result<BufReader<File>, WtfError>;
+}
+
+struct RealTerminal {}
+
+impl TerminalConfig for RealTerminal {
+    fn ghostty(&self) -> Result<String, WtfError> {
+        command_get_stdout(Command::new("ghostty").arg("+show-config"))
+    }
+
+    fn rio(&self) -> Result<BufReader<File>, WtfError> {
+        config_get_reader("rio/config.toml")
+    }
+}
+
+fn config_get_reader(config_file: &'static str) -> Result<BufReader<File>, WtfError> {
+    let config_home = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        format!(
+            "{}/.config",
+            env::var("HOME").unwrap_or_else(|_| "~".to_owned())
+        )
+    });
+    let path = format!("{}/{}", config_home, config_file);
+
+    Ok(BufReader::new(File::open(path)?))
 }
 
 fn config_get_line(
@@ -154,8 +198,36 @@ fn config_get_line(
     Err(WtfError::ConfigFile(config_file, line_prefix))
 }
 
-fn command_get_line(cmd: &mut Command, prefix: &'static str) -> Result<String, WtfError> {
+fn reader_get_line(
+    terminal: &'static str,
+    reader: BufReader<File>,
+    line_prefix: &'static str,
+) -> Result<String, WtfError> {
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with(line_prefix)
+            && let Some(font_family_line) = line.get(line_prefix.len()..)
+        {
+            return Ok(font_family_line.to_owned());
+        }
+    }
+    Err(WtfError::ConfigFile(terminal, line_prefix))
+}
+
+fn command_get_line(
+    terminal: &'static str,
+    cmd: &mut Command,
+    prefix: &'static str,
+) -> Result<String, WtfError> {
     let stdout = command_get_stdout(cmd)?;
+    stdout_get_line(terminal, stdout, prefix)
+}
+
+fn stdout_get_line(
+    terminal: &'static str,
+    stdout: String,
+    prefix: &'static str,
+) -> Result<String, WtfError> {
     for line in stdout.lines() {
         if line.starts_with(prefix)
             && let Some(font_family) = line.get(prefix.len()..)
@@ -164,13 +236,7 @@ fn command_get_line(cmd: &mut Command, prefix: &'static str) -> Result<String, W
             return Ok(font_family.to_owned());
         }
     }
-    Err(WtfError::CommandOutput(
-        cmd.get_program().to_str().unwrap_or("[missing]").to_owned(),
-        cmd.get_args()
-            .map(|arg| arg.to_str().unwrap_or("[missing]").to_owned())
-            .collect(),
-        prefix,
-    ))
+    Err(WtfError::CommandOutput(terminal, prefix))
 }
 
 fn command_get_stdout(cmd: &mut Command) -> Result<String, WtfError> {

--- a/what-terminal-font/src/lib.rs
+++ b/what-terminal-font/src/lib.rs
@@ -64,9 +64,15 @@ impl From<FromUtf8Error> for WtfError {
 /// }
 /// ```
 pub fn detect_terminal_font() -> Result<String, WtfError> {
-    let config = RealTerminal {};
-    detect_with_term_program(env::var("TERM_PROGRAM"), &config)
-        .or(detect_with_term(env::var("TERM"), &config))
+    detect(RealTerminal, env::var("TERM_PROGRAM"), env::var("TERM"))
+}
+
+fn detect(
+    config: impl TerminalConfig,
+    term_program: Result<String, env::VarError>,
+    term: Result<String, env::VarError>,
+) -> Result<String, WtfError> {
+    detect_with_term_program(term_program, &config).or(detect_with_term(term, &config))
 }
 
 fn detect_with_term_program(
@@ -121,13 +127,7 @@ fn detect_with_term(
 ) -> Result<String, WtfError> {
     if let Ok(term) = var {
         match term.as_str() {
-            "xterm-kitty" => {
-                return command_get_line(
-                    "kitty",
-                    Command::new("kitten").arg("query-terminal"),
-                    "font_family: ",
-                );
-            }
+            "xterm-kitty" => stdout_get_line("kitty", config.kitty()?, "font_family: "),
             "foot" => {
                 let line = config_get_line("foot/foot.ini", "font=")?;
                 if let Some(font_family) = line.split(':').next()
@@ -135,26 +135,32 @@ fn detect_with_term(
                 {
                     return Ok(font_family.to_owned());
                 }
-                return Err(WtfError::FontNotFound(
+                Err(WtfError::FontNotFound(
                     "foot config expected font line to contain colon separating font-family and size",
-                ));
+                ))
             }
-            _ => {}
+            _ => Err(WtfError::UnknownTerminal),
         }
+    } else {
+        Err(WtfError::UnknownTerminal)
     }
-    Err(WtfError::UnknownTerminal)
 }
 
 trait TerminalConfig {
     fn ghostty(&self) -> Result<String, WtfError>;
+    fn kitty(&self) -> Result<String, WtfError>;
     fn rio(&self) -> Result<BufReader<File>, WtfError>;
 }
 
-struct RealTerminal {}
+struct RealTerminal;
 
 impl TerminalConfig for RealTerminal {
     fn ghostty(&self) -> Result<String, WtfError> {
         command_get_stdout(Command::new("ghostty").arg("+show-config"))
+    }
+
+    fn kitty(&self) -> Result<String, WtfError> {
+        command_get_stdout(Command::new("kitten").arg("query-terminal"))
     }
 
     fn rio(&self) -> Result<BufReader<File>, WtfError> {
@@ -214,15 +220,6 @@ fn reader_get_line(
     Err(WtfError::ConfigFile(terminal, line_prefix))
 }
 
-fn command_get_line(
-    terminal: &'static str,
-    cmd: &mut Command,
-    prefix: &'static str,
-) -> Result<String, WtfError> {
-    let stdout = command_get_stdout(cmd)?;
-    stdout_get_line(terminal, stdout, prefix)
-}
-
 fn stdout_get_line(
     terminal: &'static str,
     stdout: String,
@@ -244,3 +241,6 @@ fn command_get_stdout(cmd: &mut Command) -> Result<String, WtfError> {
     let stdout = String::from_utf8(output.stdout)?;
     Ok(stdout)
 }
+
+#[cfg(test)]
+mod tests;

--- a/what-terminal-font/src/main.rs
+++ b/what-terminal-font/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
             process::exit(0);
         }
         Err(e) => {
-            eprintln!("Error detecting terminal font: {}", e);
+            eprintln!("{e}");
             process::exit(1);
         }
     }

--- a/what-terminal-font/src/main.rs
+++ b/what-terminal-font/src/main.rs
@@ -1,0 +1,16 @@
+//! Command-line tool to detect and print the terminal font, if detected correctly.
+
+use std::process;
+
+fn main() {
+    match what_terminal_font::detect_terminal_font() {
+        Ok(font) => {
+            println!("{}", font);
+            process::exit(0);
+        }
+        Err(e) => {
+            eprintln!("Error detecting terminal font: {}", e);
+            process::exit(1);
+        }
+    }
+}

--- a/what-terminal-font/src/tests.rs
+++ b/what-terminal-font/src/tests.rs
@@ -1,0 +1,82 @@
+#![expect(clippy::unwrap_used)]
+
+use super::*;
+use std::fs::File;
+use std::io::{self, BufReader};
+
+struct TestTerminal;
+
+impl TerminalConfig for TestTerminal {
+    fn ghostty(&self) -> Result<String, WtfError> {
+        Ok(r#"command = /run/current-system/sw/bin/fish
+click-repeat-interval = 500
+gtk-single-instance = false
+font-family = GhostFaceKilla
+auto-update-channel = stable
+"#
+        .to_owned())
+    }
+
+    fn kitty(&self) -> Result<String, WtfError> {
+        Ok(r#"name: kitty
+version: 0.44.0
+allow_hyperlinks: yes
+font_family: PussyKatNFM
+bold_font: PussyKatNFM-Bold
+italic_font: PussyKatNFM-Italic
+bold_italic_font: PussyKatNFM-Italic
+font_size: 12
+dpi_x: 144
+dpi_y: 144
+foreground: #dddddd
+background: #1c1a23
+background_opacity: 1
+clipboard_control: write-clipboard write-primary read-clipboard-ask read-primary-ask
+os_name: linux"#
+            .to_owned())
+    }
+
+    fn rio(&self) -> Result<BufReader<File>, WtfError> {
+        let mut temp_file = tempfile::NamedTempFile::new()?;
+        io::Write::write_all(
+            &mut temp_file,
+            b"[colors]\nbackground = '#1e1e2e'\n[font]\nfamily = \"Cascadia Code\"\nsize = 14.0",
+        )?;
+        let file = temp_file.into_file();
+        Ok(BufReader::new(file))
+    }
+}
+
+fn unrelated() -> Result<String, env::VarError> {
+    Ok("unrelated".to_owned())
+}
+
+#[test]
+fn ghostty() {
+    let result = detect(TestTerminal, Ok("ghostty".to_owned()), unrelated());
+    assert_eq!(result.unwrap(), "GhostFaceKilla");
+}
+
+#[test]
+fn wezterm() {
+    let result = detect(TestTerminal, Ok("ghostty".to_owned()), unrelated());
+    assert_eq!(result.unwrap(), "GhostFaceKilla");
+}
+
+#[test]
+fn rio() {
+    let result = detect(TestTerminal, Ok("rio".to_owned()), unrelated());
+    assert_eq!(result.unwrap(), "Cascadia Code");
+}
+
+#[test]
+fn kitty() {
+    let result = detect(TestTerminal, unrelated(), Ok("xterm-kitty".to_owned()));
+    assert_eq!(result.unwrap(), "PussyKatNFM");
+}
+
+#[test]
+fn unknown_terminal() {
+    let result = detect_with_term_program(Ok("unknown-terminal".to_owned()), &TestTerminal);
+    assert!(matches!(result.unwrap_err(), WtfError::UnknownTerminal));
+}

--- a/what-terminal-font/src/tests.rs
+++ b/what-terminal-font/src/tests.rs
@@ -40,8 +40,25 @@ os_name: linux"#
         let mut temp_file = tempfile::NamedTempFile::new()?;
         io::Write::write_all(
             &mut temp_file,
-            b"[colors]\nbackground = '#1e1e2e'\n[font]\nfamily = \"Cascadia Code\"\nsize = 14.0",
+            b"[colors]\nbackground = '#1e1e2e'\n[font]\nfamily = \"Rio De Janeiro\"\nsize = 14.0",
         )?;
+        let file = temp_file.into_file();
+        Ok(BufReader::new(file))
+    }
+
+    fn wezterm(&self) -> Result<String, WtfError> {
+        Ok(r#"{
+  "font": {
+    "family": "JetBrains Mono",
+    "size": 12.0
+  }
+}"#
+        .to_owned())
+    }
+
+    fn foot(&self) -> Result<BufReader<File>, WtfError> {
+        let mut temp_file = tempfile::NamedTempFile::new()?;
+        io::Write::write_all(&mut temp_file, b"xxx\nfont=FootPrint:size=12\nblablabla\n")?;
         let file = temp_file.into_file();
         Ok(BufReader::new(file))
     }
@@ -66,7 +83,14 @@ fn wezterm() {
 #[test]
 fn rio() {
     let result = detect(TestTerminal, Ok("rio".to_owned()), unrelated());
-    assert_eq!(result.unwrap(), "Cascadia Code");
+    assert_eq!(result.unwrap(), "Rio De Janeiro");
+}
+
+#[test]
+fn foot() {
+    let test_terminal = TestTerminal;
+    let result = detect(test_terminal, unrelated(), Ok("foot".to_owned()));
+    assert_eq!(result.unwrap(), "FootPrint");
 }
 
 #[test]

--- a/what-terminal-font/src/tests.rs
+++ b/what-terminal-font/src/tests.rs
@@ -87,6 +87,16 @@ weight = 800
         let file = temp_file.reopen()?;
         Ok(BufReader::new(file))
     }
+
+    fn xterm(&self) -> Result<BufReader<File>, WtfError> {
+        let mut temp_file = tempfile::NamedTempFile::new()?;
+        io::Write::write_all(
+            &mut temp_file,
+            b"xterm*faceName:XTermFont\nxterm.vt100.faceName:XTermVT100Font\n",
+        )?;
+        let file = temp_file.reopen()?;
+        Ok(BufReader::new(file))
+    }
 }
 
 fn unrelated() -> Result<String, env::VarError> {
@@ -116,6 +126,50 @@ fn foot() {
     let test_terminal = TestTerminal;
     let result = detect(test_terminal, unrelated(), Ok("foot".to_owned()));
     assert_eq!(result.unwrap(), "FootPrint");
+}
+
+#[test]
+fn xterm() {
+    let test_terminal = TestTerminal;
+    let result = detect(test_terminal, unrelated(), Ok("xterm".to_owned()));
+    assert_eq!(result.unwrap(), "XTermFont");
+}
+
+#[test]
+fn xterm_256color() {
+    let test_terminal = TestTerminal;
+    let result = detect(test_terminal, unrelated(), Ok("xterm-256color".to_owned()));
+    assert_eq!(result.unwrap(), "XTermFont");
+}
+
+#[test]
+fn xterm_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let mut temp_file = tempfile::NamedTempFile::new()?;
+    io::Write::write_all(&mut temp_file, b"some other config\n")?;
+    let file = temp_file.reopen()?;
+
+    struct TestTerminalFallback {
+        file: File,
+    }
+    impl TerminalConfig for TestTerminalFallback {
+        fn ghostty(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
+        fn kitty(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
+        fn rio(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
+        fn wezterm(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
+        fn foot(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
+        fn xterm(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
+    }
+
+    let test_terminal = TestTerminalFallback {
+        file: file.try_clone()?,
+    };
+    let result = detect(test_terminal, unrelated(), Ok("xterm".to_owned()));
+    match result {
+        Ok(font) => assert_eq!(font, "fixed"),
+        Err(WtfError::ConfigFile(_, _)) => {},
+        Err(e) => panic!("Unexpected error: {}", e),
+    }
+    Ok(())
 }
 
 #[test]

--- a/what-terminal-font/src/tests.rs
+++ b/what-terminal-font/src/tests.rs
@@ -143,36 +143,6 @@ fn xterm_256color() {
 }
 
 #[test]
-fn xterm_fallback() -> Result<(), Box<dyn std::error::Error>> {
-    let mut temp_file = tempfile::NamedTempFile::new()?;
-    io::Write::write_all(&mut temp_file, b"some other config\n")?;
-    let file = temp_file.reopen()?;
-
-    struct TestTerminalFallback {
-        file: File,
-    }
-    impl TerminalConfig for TestTerminalFallback {
-        fn ghostty(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
-        fn kitty(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
-        fn rio(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
-        fn wezterm(&self) -> Result<String, WtfError> { Ok("".to_owned()) }
-        fn foot(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
-        fn xterm(&self) -> Result<BufReader<File>, WtfError> { Ok(BufReader::new(self.file.try_clone()?)) }
-    }
-
-    let test_terminal = TestTerminalFallback {
-        file: file.try_clone()?,
-    };
-    let result = detect(test_terminal, unrelated(), Ok("xterm".to_owned()));
-    match result {
-        Ok(font) => assert_eq!(font, "fixed"),
-        Err(WtfError::ConfigFile(_, _)) => {},
-        Err(e) => panic!("Unexpected error: {}", e),
-    }
-    Ok(())
-}
-
-#[test]
 fn kitty() {
     let result = detect(TestTerminal, unrelated(), Ok("xterm-kitty".to_owned()));
     assert_eq!(result.unwrap(), "PussyKatNFM");

--- a/what-terminal-font/src/tests.rs
+++ b/what-terminal-font/src/tests.rs
@@ -40,26 +40,51 @@ os_name: linux"#
         let mut temp_file = tempfile::NamedTempFile::new()?;
         io::Write::write_all(
             &mut temp_file,
-            b"[colors]\nbackground = '#1e1e2e'\n[font]\nfamily = \"Rio De Janeiro\"\nsize = 14.0",
+            r#"
+[fonts]
+family = "riodejaneiro"
+extras = [{ family = "Microsoft JhengHei" }]
+features = ["ss02", "ss03", "ss05", "ss19"]
+hinting = false
+symbol-map = [
+  { start = "2297", end = "2299", font-family = "Cascadia Code NF" }
+]
+size = 18
+
+[fonts.regular]
+family = "samba"
+style = "Normal"
+weight = 400
+[fonts.bold]
+family = "samba"
+style = "Normal"
+weight = 800
+[fonts.italic]
+family = "samba"
+style = "Italic"
+weight = 400
+[fonts.bold-italic]
+family = "samba"
+style = "Italic"
+weight = 800
+"#
+            .as_bytes(),
         )?;
-        let file = temp_file.into_file();
+        let file = temp_file.reopen()?;
         Ok(BufReader::new(file))
     }
 
     fn wezterm(&self) -> Result<String, WtfError> {
-        Ok(r#"{
-  "font": {
-    "family": "JetBrains Mono",
-    "size": 12.0
-  }
-}"#
+        Ok(r#"LeftToRight
+ 0 a    \u{61}       x_adv=8  cells=1  glyph=a,68   wezterm.font("Wiz Kalifa", {weight="Regular", stretch="Normal", style="Normal"})
+                                      /nix/store/ns8ifac2f7mwisyd6dmbxb17agarhdqm-nerd-fonts-profont-3.4.0+2.3-2.2/share/fonts/truetype/NerdFonts/Wiz/WizKalifa-Regular.ttf, FontConfig"#
         .to_owned())
     }
 
     fn foot(&self) -> Result<BufReader<File>, WtfError> {
         let mut temp_file = tempfile::NamedTempFile::new()?;
         io::Write::write_all(&mut temp_file, b"xxx\nfont=FootPrint:size=12\nblablabla\n")?;
-        let file = temp_file.into_file();
+        let file = temp_file.reopen()?;
         Ok(BufReader::new(file))
     }
 }
@@ -76,14 +101,14 @@ fn ghostty() {
 
 #[test]
 fn wezterm() {
-    let result = detect(TestTerminal, Ok("ghostty".to_owned()), unrelated());
-    assert_eq!(result.unwrap(), "GhostFaceKilla");
+    let result = detect(TestTerminal, Ok("WezTerm".to_owned()), unrelated());
+    assert_eq!(result.unwrap(), "Wiz Kalifa");
 }
 
 #[test]
 fn rio() {
     let result = detect(TestTerminal, Ok("rio".to_owned()), unrelated());
-    assert_eq!(result.unwrap(), "Rio De Janeiro");
+    assert_eq!(result.unwrap(), "riodejaneiro");
 }
 
 #[test]


### PR DESCRIPTION
I want to autodetect the terminal font, if possible, and then skip the font setup interface if detected correctly.

* [x] actually use the detected font
* [ ] ~~fuzzy match against system fonts (e.g. kitty says `EnvyCodeRNFM` vs `EnvyCodeR Nerd Font Mono`)~~
* [x] ghostty
* [x] kitty
* [x] foot
* [x] rio
* [x] wezterm
* [x] xterm
* [ ] iterm2 (maybe never)
* [ ] mlterm
* [ ] blackbox
* [ ] bobcat
* [ ] konsole