### PR TITLE
put global logger behind OnceLock, include logs of view()

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,6 @@
-use std::io::Write;
+use std::{io::Write, sync::OnceLock};
 
-use flexi_logger::{DeferredNow, FileSpec, FlexiLoggerError, Logger};
+use flexi_logger::{DeferredNow, FileSpec, FlexiLoggerError, Logger, LoggerHandle};
 use log::Record;
 use ratatui::{
     Frame,
@@ -11,8 +11,10 @@ use ratatui::{
 };
 use textwrap::{Options, wrap};
 
-pub fn ui_logger(log_to_file: bool) -> Result<flexi_logger::LoggerHandle, FlexiLoggerError> {
-    if log_to_file {
+static LOGGER: OnceLock<LoggerHandle> = OnceLock::new();
+
+pub fn init_logger(log_to_file: bool) -> Result<(), FlexiLoggerError> {
+    let logger = if log_to_file {
         Logger::try_with_env_or_str("info")?
             .log_to_file(FileSpec::default())
             .start()
@@ -20,7 +22,11 @@ pub fn ui_logger(log_to_file: bool) -> Result<flexi_logger::LoggerHandle, FlexiL
         Logger::try_with_env_or_str("info")?
             .log_to_buffer(10000, Some(markdown_format))
             .start()
+    }?;
+    if let Err(_logger) = LOGGER.set(logger) {
+        panic!("error initializing global logger: already initialized.");
     }
+    Ok(())
 }
 
 fn markdown_format(
@@ -37,7 +43,7 @@ fn markdown_format(
     )
 }
 
-pub fn render_snapshot(snapshot: &flexi_logger::Snapshot, frame: &mut Frame) -> Rect {
+pub fn render_snapshot(snapshot: &flexi_logger::Snapshot, frame: &mut Frame) {
     let debug_block = Block::bordered().title("logs");
 
     let frame_area = frame.area();
@@ -86,7 +92,6 @@ pub fn render_snapshot(snapshot: &flexi_logger::Snapshot, frame: &mut Frame) -> 
         );
         frame.render_widget(line, rect);
     }
-    half_area_left
 }
 
 /// Parse a log line in format: **LEVEL** *module* `message`
@@ -150,4 +155,10 @@ fn parse_log_line(line: &str) -> Line<'static> {
     }
 
     Line::from(spans)
+}
+
+pub fn update_snapshot(snapshot: &mut flexi_logger::Snapshot) -> Option<bool> {
+    LOGGER
+        .get()
+        .and_then(|logger| logger.update_snapshot(snapshot).ok())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ use std::{
 };
 
 use clap::{ArgMatches, arg, command, value_parser};
-use flexi_logger::LoggerHandle;
 use ratatui::{
     DefaultTerminal, Terminal,
     crossterm::{
@@ -118,7 +117,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
         return Ok(());
     }
 
-    let ui_logger = debug::ui_logger(*matches.get_one("log").unwrap_or(&false))?;
+    debug::init_logger(*matches.get_one("log").unwrap_or(&false))?;
 
     let path = matches.get_one::<PathBuf>("path");
 
@@ -254,7 +253,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
         None
     };
 
-    run(&mut terminal, model, &ui_logger)?;
+    run(&mut terminal, model)?;
     drop(debouncer);
 
     // Cursor might be in wird places, prompt or whatever should always show at the bottom now.
@@ -349,11 +348,7 @@ impl std::fmt::Debug for Event {
     }
 }
 
-fn run(
-    terminal: &mut DefaultTerminal,
-    mut model: Model,
-    ui_logger: &LoggerHandle,
-) -> Result<(), Error> {
+fn run(terminal: &mut DefaultTerminal, mut model: Model) -> Result<(), Error> {
     terminal.draw(|frame| view(&model, frame))?;
     loop {
         let (had_events, _, had_reload) = model.process_events()?;
@@ -366,10 +361,13 @@ fn run(
         };
 
         if (had_events || had_input) && !skip_render && !had_reload {
-            if let Some(ref mut snapshot) = model.log_snapshot {
-                ui_logger.update_snapshot(snapshot)?;
-            }
-            terminal.draw(|frame| view(&model, frame))?;
+            terminal.draw(|frame| {
+                view(&model, frame);
+                if let Some(snapshot) = &mut model.log_snapshot {
+                    debug::update_snapshot(snapshot);
+                    debug::render_snapshot(snapshot, frame);
+                }
+            })?;
         }
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -24,12 +24,13 @@ pub fn view(model: &Model, frame: &mut Frame) {
     let padding = model.block_padding(frame_area);
     block = block.padding(padding);
 
-    let inner_area = if let Some(snapshot) = &model.log_snapshot {
-        let area = crate::debug::render_snapshot(snapshot, frame);
+    let inner_area = if model.log_snapshot.is_some() {
+        let mut half_area_left = frame_area;
+        half_area_left.width /= 2;
         let mut fixed_padding = padding;
         fixed_padding.right = 0;
         block = block.padding(fixed_padding);
-        block.inner(area)
+        block.inner(half_area_left)
     } else {
         block.inner(frame_area)
     };


### PR DESCRIPTION
Just so much more simple to have a global logger.

Update log snapshot and render *after* view() returns, so that debug logs inside view() also show up in the UI logs.