### PR TITLE
reset color after header on kitty

### DIFF
--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -100,6 +100,12 @@ impl<'a> BigText<'a> {
             symbol.extend(chunk);
             write!(symbol, "\x1b\\").expect("write to string");
         }
+
+        if self.color.is_some() {
+            // Reset color
+            write!(symbol, "\x1b[0m").expect("write to string");
+        }
+
         symbol
     }
 }


### PR DESCRIPTION
Kitty just uses regular ANSI color for BigText, so it needs to reset the color or following text keeps the header color.

Fixes #115 