### PR TITLE
query terminal background color and render smooth sixel headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f91458ac9dca7d54e0b6220141f984babed54b651cec4674e25865067b7dbbd"
+checksum = "535e2a5f434ea3308977e6664b4386c3d663951a222e338cb7480d8742fe7773"
 dependencies = [
  "base64-simd",
  "icy_sixel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ notify = "8.1.0"
 notify-debouncer-mini = "0.6.0"
 open = "5.3.3"
 ratatui = { version = "^0.30.0", features = ["serde", "crossterm_0_29"] }
-ratatui-image = { version = "11.0.1", default-features = false, features = ["serde"] }
+ratatui-image = { version = "11.0.2", default-features = false, features = ["serde"] }
 regex = "1.11.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 unicode-width = "0.2.2"

--- a/src/document.rs
+++ b/src/document.rs
@@ -11,8 +11,8 @@ use itertools::Either;
 
 use cosmic_text::{Attrs, Buffer, Family, Metrics, Shaping};
 use image::{
-    DynamicImage, GenericImage as _, ImageFormat, ImageReader, Rgba, RgbaImage,
-    imageops::FilterType,
+    DynamicImage, GenericImage as _, GenericImageView as _, ImageFormat, ImageReader, Pixel as _,
+    Rgba, RgbaImage, imageops::FilterType,
 };
 use mdfrier::{MarkdownLink, SourceContent};
 use ratatui::{layout::Size, text::Line};
@@ -649,14 +649,18 @@ pub fn header_images(
     buffer.shape_until_scroll(&mut font_renderer.font_system, false);
 
     // Make one image per shaped line.
-    let run_count = buffer.layout_runs().collect::<Vec<_>>().len();
+    let layout_runs = buffer.layout_runs().collect::<Vec<_>>();
+    let run_count = layout_runs.len();
     let mut dyn_imgs = Vec::with_capacity(run_count);
     let img_height = u32::from(font_height * 2);
     let img_width = u32::from(width * font_width);
-    for layout_run in buffer.layout_runs() {
-        const RGBA_BG: [u8; 4] = [0, 0, 0, 0];
-        let img: RgbaImage =
-            RgbaImage::from_pixel(img_width, img_height, Rgba::<u8>::from(RGBA_BG));
+    const DEFAULT_RGBA_BG: [u8; 4] = [0, 0, 0, 0];
+    let background_color = font_renderer
+        .background_color
+        .unwrap_or_else(|| Rgba::<u8>::from(DEFAULT_RGBA_BG));
+
+    for layout_run in layout_runs {
+        let img: RgbaImage = RgbaImage::from_pixel(img_width, img_height, background_color);
         let dyn_img = DynamicImage::ImageRgba8(img);
         dyn_imgs.push((layout_run.text.into(), tier, dyn_img));
     }
@@ -693,7 +697,19 @@ pub fn header_images(
 
             // Adjust picked image's Y coord offset.
             let y_offset: u32 = index as u32 * img_height;
-            dyn_img.put_pixel(x as u32, y as u32 - y_offset, color.as_rgba().into());
+
+            if font_renderer.background_color.is_some() {
+                // Blend the pixels in with background color.
+                let px = x as u32;
+                let py = y as u32 - y_offset;
+                let fg: Rgba<u8> = color.as_rgba().into();
+                let mut bg = dyn_img.get_pixel(px, py);
+                bg.blend(&fg);
+                dyn_img.put_pixel(px, py, bg);
+            } else {
+                // Just write on the fully transparent image.
+                dyn_img.put_pixel(x as u32, y as u32 - y_offset, color.as_rgba().into());
+            }
         },
     );
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,6 +3,7 @@ mod fontpicker;
 pub mod notification;
 
 use cosmic_text::{Color, FontSystem, SwashCache};
+use image::Rgba;
 use ratatui_image::{
     FontSize,
     picker::{Capability, Picker, ProtocolType, cap_parser::QueryStdioOptions},
@@ -21,6 +22,7 @@ pub struct FontRenderer {
     pub font_system: FontSystem,
     pub font_color: Color,
     pub swash_cache: SwashCache,
+    pub background_color: Option<Rgba<u8>>,
 }
 
 impl FontRenderer {
@@ -30,6 +32,7 @@ impl FontRenderer {
         font_name: String,
         font_size: FontSize,
         font_color: Option<Color>,
+        background_color: Option<Rgba<u8>>,
     ) -> Self {
         FontRenderer {
             font_size,
@@ -37,6 +40,7 @@ impl FontRenderer {
             font_system,
             font_color: font_color.unwrap_or_else(|| Color::rgba(255, 255, 255, 255)),
             swash_cache,
+            background_color,
         }
     }
 }
@@ -57,15 +61,25 @@ pub fn setup_graphics(
     no_cap_checks: bool,
     debug_override_protocol_type: Option<ProtocolType>,
 ) -> Result<SetupResult, Error> {
-    let mut picker = if no_cap_checks {
-        Picker::halfblocks()
+    let (mut picker, background_color) = if no_cap_checks {
+        (Picker::halfblocks(), None)
     } else {
         print!("Detecting supported graphics protocols...");
-        let mut options = QueryStdioOptions::default();
-        options.text_sizing_protocol = true;
-        let picker = Picker::from_query_stdio_with_options(options)?;
+        let picker = Picker::from_query_stdio_with_options(QueryStdioOptions {
+            text_sizing_protocol: true,
+            terminal_background_color_osc: true,
+            ..Default::default()
+        })?;
         println!(" {:?}.", picker.protocol_type());
-        picker
+        let mut bg = None;
+        if picker.protocol_type() == ProtocolType::Sixel {
+            for cap in picker.capabilities() {
+                if let Capability::Background(r, g, b) = cap {
+                    bg = Some(Rgba::from([*r, *g, *b, 255]));
+                }
+            }
+        }
+        (picker, bg)
     };
 
     let has_text_size_protocol = picker
@@ -153,6 +167,7 @@ pub fn setup_graphics(
                     _ => Color::rgba(255, 255, 255, 255),
                 })
             }),
+            background_color,
         )),
     ))
 }

--- a/src/setup/fontpicker.rs
+++ b/src/setup/fontpicker.rs
@@ -49,6 +49,7 @@ pub fn interactive_font_picker(
         String::new(),
         picker.font_size(),
         None,
+        None,
     );
 
     println!("{} system fonts detected.", lowercase_fonts.len());


### PR DESCRIPTION
1. Query terminal background color with ratatui-image.
2. Blend in header pixels on top of background color, if Sixel.

Gets rid of jagged edges on header text with sixels.