### PR TITLE
open URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,9 +1185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1216,6 +1225,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "ghrepo"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2508da0b48f2f45c3f9dea89d149d04a5f74a76c42401373fde6976be6e4ca"
 
 [[package]]
 name = "gif"
@@ -1999,6 +2014,7 @@ dependencies = [
  "crossterm 0.29.0",
  "ctor",
  "flexi_logger",
+ "ghrepo",
  "image",
  "insta",
  "itertools 0.14.0",
@@ -2020,6 +2036,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-md",
  "unicode-width",
+ "url",
  "what-terminal-font",
 ]
 
@@ -4198,9 +4215,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ clap = { version = "4.5.21", features = ["cargo", "derive"] }
 confy = "0.6.1"
 cosmic-text = "0.18.2"
 crossterm = { version = "0.29", features = ["use-dev-tty"] }
+flexi_logger = { version = "0.31.7", features = ["buffer_writer"] }
+ghrepo = "0.7.1"
 image = "0.25.2"
 itertools = "0.14.0"
 libc = { version = "0.2", default-features = false }
@@ -40,14 +42,14 @@ ratatui = { version = "^0.30.0", features = ["serde", "crossterm_0_29"] }
 ratatui-image = { version = "11.0.2", default-features = false, features = ["serde"] }
 regex = "1.11.1"
 resvg = { version = "0.47.0", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "blocking"] }
 unicode-width = "0.2.2"
 serde = { version = "^1.0", features = ["derive"] }
 textwrap = "0.16.2"
 tokio = { version = "1.32.0", features = ["full"] }
 tree-sitter = "0.26"
 tree-sitter-md = "0.5"
-flexi_logger = { version = "0.31.7", features = ["buffer_writer"] }
+url = "2.5.8"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub watch_debounce_milliseconds: u64,
     pub enable_mouse_capture: bool,
     pub debug_override_protocol_type: Option<ProtocolType>,
+    pub url_transform_command: Option<String>,
     pub theme: Theme,
 }
 
@@ -29,6 +30,7 @@ impl From<UserConfig> for Config {
             watch_debounce_milliseconds: uc.watch_debounce_milliseconds.unwrap_or(100),
             enable_mouse_capture: uc.enable_mouse_capture.unwrap_or(false),
             debug_override_protocol_type: uc.debug_override_protocol_type,
+            url_transform_command: uc.url_transform_command,
             theme: uc.theme.unwrap_or_else(|| Theme {
                 hide_urls: Some(true),
                 ..Default::default()
@@ -46,6 +48,7 @@ pub struct UserConfig {
     pub watch_debounce_milliseconds: Option<u64>,
     pub enable_mouse_capture: Option<bool>,
     pub debug_override_protocol_type: Option<ProtocolType>,
+    pub url_transform_command: Option<String>,
     pub theme: Option<Theme>,
 }
 
@@ -369,7 +372,8 @@ pub fn print_default() -> Result<(), Error> {
         max_image_height: Some(config.max_image_height),
         watch_debounce_milliseconds: Some(config.watch_debounce_milliseconds),
         enable_mouse_capture: Some(config.enable_mouse_capture),
-        debug_override_protocol_type: config.debug_override_protocol_type,
+        debug_override_protocol_type: None,
+        url_transform_command: Some("readable | html2text".to_owned()),
         theme: Some(Theme::defaults_for_print()),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod error;
 mod keybindings;
 mod model;
 mod setup;
+mod sources;
 mod view;
 mod watch;
 mod worker;
@@ -16,10 +17,7 @@ use std::os::fd::IntoRawFd as _;
 
 use std::{
     fmt::Display,
-    fs::read_to_string,
-    io::{self, Read as _, Write as _},
-    path::{Path, PathBuf},
-    process::{Command, Stdio},
+    io::{self, Read as _},
     sync::{
         OnceLock,
         mpsc::{self},
@@ -39,7 +37,6 @@ use ratatui::{
 
 use mdfrier::MarkdownLink;
 use ratatui_image::{picker::ProtocolType, protocol::Protocol, sliced::SlicedProtocol};
-use reqwest::header::CONTENT_TYPE;
 use setup::{SetupResult, setup_graphics};
 
 use crate::{
@@ -48,14 +45,15 @@ use crate::{
     error::Error,
     keybindings::PollResult,
     model::{DocumentId, Model},
+    sources::open_source,
     view::view,
     watch::watch,
     worker::{ImageCache, worker_thread},
 };
 
-const OK_END: &str = " ok.";
+pub const OK_END: &str = " ok.";
 
-static VERSION: OnceLock<String> = OnceLock::new();
+pub static VERSION: OnceLock<String> = OnceLock::new();
 
 fn main() -> io::Result<()> {
     let mut cmd = command!() // requires `cargo` feature
@@ -387,109 +385,6 @@ fn run(terminal: &mut DefaultTerminal, mut model: Model) -> Result<(), Error> {
             })?;
         }
     }
-}
-
-fn open_source(
-    source: &str,
-    url_transform_command: Option<String>,
-) -> Result<(String, Option<PathBuf>, Option<PathBuf>), Error> {
-    use ghrepo::GHRepo;
-    use url::Url;
-
-    log::debug!("source: {source:?}");
-    use core::str::FromStr as _;
-    if let Some(handle) = source.strip_prefix("github:")
-        && let Ok(repo) = GHRepo::from_str(handle)
-    {
-        // We only want to try github if the user explicitly prefixed with "github:...".
-        // Otherwise a path like "dir/file.md" would be a valid GHRepo and cause a useless request.
-        let owner = repo.owner();
-        let name = repo.name();
-        let client = reqwest::blocking::Client::builder()
-            .user_agent(format!(
-                "mdfried/{}",
-                VERSION.get().unwrap_or(&"unknown".to_owned())
-            ))
-            .build()?;
-        for branch in ["master", "main"] {
-            let url = format!(
-                "https://raw.githubusercontent.com/{owner}/{name}/refs/heads/{branch}/README.md"
-            );
-            log::info!("trying github URL: {url}");
-            print!("Fetching URL {url}...");
-            let response = client.get(&url).send()?;
-            if response.status().is_success() {
-                println!("{OK_END}");
-                return Ok((response.text()?, None, None));
-            } else {
-                println!("error.");
-            }
-        }
-        return Err(Error::Io(io::Error::other(format!(
-            "failed to request https://raw.githubusercontent.com/{owner}/{name}/refs/heads/[master|main]/README.md"
-        ))));
-    } else if let Ok(url) = Url::parse(source) {
-        log::info!("requesting URL: {url}");
-        print!("Fetching URL {url}...");
-        let client = reqwest::blocking::Client::builder()
-            .user_agent(format!(
-                "mdfried/{}",
-                VERSION.get().unwrap_or(&"unknown".to_owned())
-            ))
-            .build()?;
-        let response = client.get(url.as_ref()).send()?;
-        if response.status().is_success() {
-            println!("{OK_END}");
-            log::debug!(
-                "have url_transform_command? {}, content_type: {:?}",
-                url_transform_command.is_some(),
-                response.headers().get(CONTENT_TYPE)
-            );
-            if let Some(url_transform_command) = url_transform_command
-                && let Some(content_type) = response.headers().get(CONTENT_TYPE)
-                && content_type
-                    .to_str()
-                    .map_err(|err| {
-                        Error::Io(io::Error::other(format!("content-type error: {err}")))
-                    })?
-                    .starts_with("text/html")
-            {
-                let mut child = Command::new("sh")
-                    .arg("-c")
-                    .arg(url_transform_command)
-                    .env("URL", url.as_ref())
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()?;
-
-                let Some(stdin) = child.stdin.as_mut() else {
-                    return Err(Error::Io(io::Error::other(
-                        "url_transform_command pipe error",
-                    )));
-                };
-                stdin.write_all(response.text()?.as_bytes())?;
-
-                let output = child.wait_with_output()?;
-
-                return Ok((
-                    String::from_utf8(output.stdout)
-                        .map_err(|_err| Error::Io(io::Error::other("response not utf-8")))?,
-                    None,
-                    None,
-                ));
-            }
-            return Ok((response.text()?, None, None));
-        } else {
-            println!("error.");
-            return Err(Error::Io(io::Error::other(format!(
-                "failed to request {url}"
-            ))));
-        }
-    }
-
-    let path = PathBuf::from(source);
-    let basepath = path.parent().map(Path::to_path_buf);
-    Ok((read_to_string(&path)?, Some(path), basepath))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::os::fd::IntoRawFd as _;
 
 use std::{
     fmt::Display,
-    fs::{self, File},
+    fs::read_to_string,
     io::{self, Read as _},
     path::{Path, PathBuf},
     sync::{
@@ -74,8 +74,7 @@ fn main() -> io::Result<()> {
                 .value_parser(value_parser!(bool)),
         )
         .arg(
-            arg!([path] "The markdown file path, or '-', or omit, for stdin")
-                .value_parser(value_parser!(PathBuf)),
+            arg!([source] "The markdown source.\nCan be a file path, a URL, a github repo in \"github:[owner]/[repo]\" format, or '-' or omit, for stdin")
         );
     let matches = cmd.get_matches_mut();
 
@@ -130,32 +129,29 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
 
     debug::init_logger(*matches.get_one("log-to-stderr").unwrap_or(&false))?;
 
-    let path = matches.get_one::<PathBuf>("path");
+    let source: Option<String> = matches.get_one::<String>("source").cloned();
 
-    let (text, basepath) = match path {
-        Some(path) if path.as_os_str() == "-" => {
+    let (text, file_path, basepath) = match source {
+        Some(source) if source == "-" => {
             let mut text = String::new();
             print!("Reading stdin...");
             io::stdin().read_to_string(&mut text)?;
             println!("{OK_END}");
-            (text, None)
+            (text, None, None)
         }
         None => {
             if io::stdin().is_tty() {
                 return Err(Error::Usage(Some(
-                    "no path nor '-', and stdin is a tty (not a pipe)",
+                    "no source nor '-', and stdin is a tty (not a pipe)",
                 )));
             }
             let mut text = String::new();
             print!("Reading stdin...");
             io::stdin().read_to_string(&mut text)?;
             println!("{OK_END}");
-            (text, None)
+            (text, None, None)
         }
-        Some(path) => (
-            fs::read_to_string(path)?,
-            path.parent().map(Path::to_path_buf),
-        ),
+        Some(source) => open_source(&source)?,
     };
 
     if text.is_empty() {
@@ -173,7 +169,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
         // Calls some libc, not sure if this could be done otherwise.
         unsafe {
             // Attempt to open /dev/tty which will give us a new stdin
-            let tty = File::open("/dev/tty")?;
+            let tty = std::fs::File::open("/dev/tty")?;
 
             // Get the file descriptor for /dev/tty
             let tty_fd = tty.into_raw_fd();
@@ -219,7 +215,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
     let deep_fry = *matches.get_one("deep-fry").unwrap_or(&false);
 
     let watchmode_path = if *matches.get_one("watch").unwrap_or(&false) {
-        path.cloned()
+        file_path.clone()
     } else {
         None
     };
@@ -253,7 +249,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
     terminal.clear()?;
 
     let terminal_size = terminal.size()?;
-    let model = Model::new(path.cloned(), cmd_tx, event_rx, terminal.size()?, config);
+    let model = Model::new(file_path, cmd_tx, event_rx, terminal.size()?, config);
     model.open(terminal_size, text)?;
 
     let debouncer = if let Some(path) = watchmode_path {
@@ -389,6 +385,68 @@ fn run(terminal: &mut DefaultTerminal, mut model: Model) -> Result<(), Error> {
             })?;
         }
     }
+}
+
+fn open_source(source: &str) -> Result<(String, Option<PathBuf>, Option<PathBuf>), Error> {
+    use ghrepo::GHRepo;
+    use url::Url;
+
+    log::debug!("source: {source:?}");
+    use core::str::FromStr as _;
+    if let Some(handle) = source.strip_prefix("github:")
+        && let Ok(repo) = GHRepo::from_str(handle)
+    {
+        // We only want to try github if the user explicitly prefixed with "github:...".
+        // Otherwise a path like "dir/file.md" would be a valid GHRepo and cause a useless request.
+        let owner = repo.owner();
+        let name = repo.name();
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!(
+                "mdfried/{}",
+                VERSION.get().unwrap_or(&"unknown".to_owned())
+            ))
+            .build()?;
+        for branch in ["master", "main"] {
+            let url = format!(
+                "https://raw.githubusercontent.com/{owner}/{name}/refs/heads/{branch}/README.md"
+            );
+            log::info!("trying github URL: {url}");
+            print!("Fetching URL {url}...");
+            let response = client.get(&url).send()?;
+            if response.status().is_success() {
+                println!("{OK_END}");
+                return Ok((response.text()?, None, None));
+            } else {
+                println!("error.");
+            }
+        }
+        return Err(Error::Io(io::Error::other(format!(
+            "failed to request https://raw.githubusercontent.com/{owner}/{name}/refs/heads/[master|main]/README.md"
+        ))));
+    } else if let Ok(url) = Url::parse(source) {
+        log::info!("requesting URL: {url}");
+        print!("Fetching URL {url}...");
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!(
+                "mdfried/{}",
+                VERSION.get().unwrap_or(&"unknown".to_owned())
+            ))
+            .build()?;
+        let response = client.get(url.as_ref()).send()?;
+        if response.status().is_success() {
+            println!("{OK_END}");
+            return Ok((response.text()?, None, None));
+        } else {
+            println!("error.");
+            return Err(Error::Io(io::Error::other(format!(
+                "failed to request {url}"
+            ))));
+        }
+    }
+
+    let path = PathBuf::from(source);
+    let basepath = path.parent().map(Path::to_path_buf);
+    Ok((read_to_string(&path)?, Some(path), basepath))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ use std::os::fd::IntoRawFd as _;
 use std::{
     fmt::Display,
     fs::read_to_string,
-    io::{self, Read as _},
+    io::{self, Read as _, Write as _},
     path::{Path, PathBuf},
+    process::{Command, Stdio},
     sync::{
         OnceLock,
         mpsc::{self},
@@ -38,6 +39,7 @@ use ratatui::{
 
 use mdfrier::MarkdownLink;
 use ratatui_image::{picker::ProtocolType, protocol::Protocol, sliced::SlicedProtocol};
+use reqwest::header::CONTENT_TYPE;
 use setup::{SetupResult, setup_graphics};
 
 use crate::{
@@ -131,6 +133,9 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
 
     let source: Option<String> = matches.get_one::<String>("source").cloned();
 
+    let mut user_config = config::load_or_ask()?;
+    let config = Config::from(user_config.clone());
+
     let (text, file_path, basepath) = match source {
         Some(source) if source == "-" => {
             let mut text = String::new();
@@ -151,15 +156,12 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
             println!("{OK_END}");
             (text, None, None)
         }
-        Some(source) => open_source(&source)?,
+        Some(source) => open_source(&source, config.url_transform_command.clone())?,
     };
 
     if text.is_empty() {
         return Err(Error::Usage(Some("no input or empty")));
     }
-
-    let mut user_config = config::load_or_ask()?;
-    let config = Config::from(user_config.clone());
 
     #[cfg(not(windows))]
     if !io::stdin().is_tty() {
@@ -387,7 +389,10 @@ fn run(terminal: &mut DefaultTerminal, mut model: Model) -> Result<(), Error> {
     }
 }
 
-fn open_source(source: &str) -> Result<(String, Option<PathBuf>, Option<PathBuf>), Error> {
+fn open_source(
+    source: &str,
+    url_transform_command: Option<String>,
+) -> Result<(String, Option<PathBuf>, Option<PathBuf>), Error> {
     use ghrepo::GHRepo;
     use url::Url;
 
@@ -435,6 +440,44 @@ fn open_source(source: &str) -> Result<(String, Option<PathBuf>, Option<PathBuf>
         let response = client.get(url.as_ref()).send()?;
         if response.status().is_success() {
             println!("{OK_END}");
+            log::debug!(
+                "have url_transform_command? {}, content_type: {:?}",
+                url_transform_command.is_some(),
+                response.headers().get(CONTENT_TYPE)
+            );
+            if let Some(url_transform_command) = url_transform_command
+                && let Some(content_type) = response.headers().get(CONTENT_TYPE)
+                && content_type
+                    .to_str()
+                    .map_err(|err| {
+                        Error::Io(io::Error::other(format!("content-type error: {err}")))
+                    })?
+                    .starts_with("text/html")
+            {
+                let mut child = Command::new("sh")
+                    .arg("-c")
+                    .arg(url_transform_command)
+                    .env("URL", url.as_ref())
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()?;
+
+                let Some(stdin) = child.stdin.as_mut() else {
+                    return Err(Error::Io(io::Error::other(
+                        "url_transform_command pipe error",
+                    )));
+                };
+                stdin.write_all(response.text()?.as_bytes())?;
+
+                let output = child.wait_with_output()?;
+
+                return Ok((
+                    String::from_utf8(output.stdout)
+                        .map_err(|_err| Error::Io(io::Error::other("response not utf-8")))?,
+                    None,
+                    None,
+                ));
+            }
             return Ok((response.text()?, None, None));
         } else {
             println!("error.");

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,0 +1,112 @@
+use std::{
+    fs::read_to_string,
+    io::{self, Write as _},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use reqwest::header::CONTENT_TYPE;
+
+use crate::{OK_END, VERSION, error::Error};
+
+pub fn open_source(
+    source: &str,
+    url_transform_command: Option<String>,
+) -> Result<(String, Option<PathBuf>, Option<PathBuf>), Error> {
+    use ghrepo::GHRepo;
+    use url::Url;
+
+    use core::str::FromStr as _;
+    if let Some(handle) = source.strip_prefix("github:")
+        && let Ok(repo) = GHRepo::from_str(handle)
+    {
+        // We only want to try github if the user explicitly prefixed with "github:...".
+        // Otherwise a path like "dir/file.md" would be a valid GHRepo and cause a useless request.
+        let owner = repo.owner();
+        let name = repo.name();
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!(
+                "mdfried/{}",
+                VERSION.get().unwrap_or(&"unknown".to_owned())
+            ))
+            .build()?;
+        for branch in ["master", "main"] {
+            let url = format!(
+                "https://raw.githubusercontent.com/{owner}/{name}/refs/heads/{branch}/README.md"
+            );
+            log::info!("trying github URL: {url}");
+            print!("Fetching URL {url}...");
+            let response = client.get(&url).send()?;
+            if response.status().is_success() {
+                println!("{OK_END}");
+                return Ok((response.text()?, None, None));
+            } else {
+                println!("error.");
+            }
+        }
+        return Err(Error::Io(io::Error::other(format!(
+            "failed to request https://raw.githubusercontent.com/{owner}/{name}/refs/heads/[master|main]/README.md"
+        ))));
+    } else if let Ok(url) = Url::parse(source) {
+        log::info!("requesting URL: {url}");
+        print!("Fetching URL {url}...");
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!(
+                "mdfried/{}",
+                VERSION.get().unwrap_or(&"unknown".to_owned())
+            ))
+            .build()?;
+        let response = client.get(url.as_ref()).send()?;
+        if response.status().is_success() {
+            println!("{OK_END}");
+            log::debug!(
+                "have url_transform_command? {}, content_type: {:?}",
+                url_transform_command.is_some(),
+                response.headers().get(CONTENT_TYPE)
+            );
+            if let Some(url_transform_command) = url_transform_command
+                && let Some(content_type) = response.headers().get(CONTENT_TYPE)
+                && content_type
+                    .to_str()
+                    .map_err(|err| {
+                        Error::Io(io::Error::other(format!("content-type error: {err}")))
+                    })?
+                    .starts_with("text/html")
+            {
+                let mut child = Command::new("sh")
+                    .arg("-c")
+                    .arg(url_transform_command)
+                    .env("URL", url.as_ref())
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()?;
+
+                let Some(stdin) = child.stdin.as_mut() else {
+                    return Err(Error::Io(io::Error::other(
+                        "url_transform_command pipe error",
+                    )));
+                };
+                stdin.write_all(response.text()?.as_bytes())?;
+
+                let output = child.wait_with_output()?;
+
+                return Ok((
+                    String::from_utf8(output.stdout)
+                        .map_err(|_err| Error::Io(io::Error::other("response not utf-8")))?,
+                    None,
+                    None,
+                ));
+            }
+            return Ok((response.text()?, None, None));
+        } else {
+            println!("error.");
+            return Err(Error::Io(io::Error::other(format!(
+                "failed to request {url}"
+            ))));
+        }
+    }
+
+    let path = PathBuf::from(source);
+    let basepath = path.parent().map(Path::to_path_buf);
+    Ok((read_to_string(&path)?, Some(path), basepath))
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -56,11 +56,14 @@ pub fn worker_thread(
         runtime.block_on(async {
 
             let basepath = basepath.clone();
-            let client = Arc::new(RwLock::new({
+            let client = Arc::new(RwLock::new(
                 Client::builder()
-                .user_agent(format!("mdfried/{}", VERSION.get().unwrap_or(&"unknown".to_owned())))
-                .build()?
-            }));
+                    .user_agent(format!(
+                        "mdfried/{}",
+                        VERSION.get().unwrap_or(&"unknown".to_owned())
+                    ))
+                    .build()?
+            ));
 
             #[cfg(feature = "svg")]
             let fontdb = renderer
@@ -77,7 +80,9 @@ pub fn worker_thread(
                     #[expect(clippy::cfg_not_test)]
                     #[cfg(not(test))]
                     {
-                        log::warn!("loading system fonts for SVG");
+                        if !theme.has_text_size_protocol.unwrap_or_default() {
+                            log::warn!("loading system fonts for SVG despite not using text-size-protocol");
+                        }
                         let mut fontdb = Database::new();
                         fontdb.load_system_fonts(); // loads all system fonts
                         Some(Arc::new(fontdb))

--- a/src/worker/link_tracker.rs
+++ b/src/worker/link_tracker.rs
@@ -44,7 +44,13 @@ impl LinkTracker {
                 .is_link_modifier(MdModifier::LinkDescriptionWrapper)
         {
             // Exit link description before this span.
-            self.link_builder = LinkExtraLinkBuilder::StartEnd(start, self.offset);
+            if self.offset > start {
+                self.link_builder = LinkExtraLinkBuilder::StartEnd(start, self.offset);
+            } else {
+                log::error!("LinkExtraLinkBuilder::Start(start) > offset");
+                // TODO: this needs fixing!
+                self.link_builder = LinkExtraLinkBuilder::None;
+            }
         } else if let LinkExtraLinkBuilder::StartEnd(start, end) = self.link_builder
             && node.modifiers.is_link_modifier(MdModifier::LinkURLWrapper)
         {


### PR DESCRIPTION
Changed `[path]` argument to `[source]`. Can be a path like usual, or a URL, or a `github:owner/repo` handle. In case of using a github handle, the README.md will from raw.githubusercontent.com will be tried from `master` and `main` branches.

Closes #70