### PR TITLE
fix line-breaking URLs

### DIFF
--- a/mdfrier/src/lib.rs
+++ b/mdfrier/src/lib.rs
@@ -100,6 +100,8 @@ mod wrap;
 #[cfg(feature = "ratatui")]
 pub mod ratatui;
 
+use std::fmt::Display;
+
 use tree_sitter::Parser;
 
 pub use lines::LineIterator;
@@ -147,13 +149,42 @@ pub enum LineKind {
     Blank,
 }
 
+#[cfg(test)]
+impl Display for Line {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.spans
+                .iter()
+                .map(|s| s.content.clone())
+                .collect::<Vec<String>>()
+                .join("")
+        )
+    }
+}
+
+#[cfg(test)]
+impl Line {
+    fn to_strings<T>(lines: T) -> Vec<String>
+    where
+        T: IntoIterator,
+        T::Item: Display,
+    {
+        lines
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct MarkdownLink {
     pub url: String,
     pub description: String,
 }
 
-impl std::fmt::Display for MarkdownLink {
+impl Display for MarkdownLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{}]({})", self.description, self.url)
     }
@@ -163,7 +194,7 @@ impl std::fmt::Display for MarkdownLink {
 #[derive(Debug)]
 pub struct MarkdownParseError;
 
-impl std::fmt::Display for MarkdownParseError {
+impl Display for MarkdownParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Failed to parse markdown")
     }

--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -954,7 +954,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn line_iterator_clean_links_nested_image() {
         let mut parser = make_parser();
         let mut inline_parser = make_inline_parser();
@@ -1006,6 +1005,9 @@ mod tests {
                         Modifier::Link | Modifier::LinkDescription | Modifier::Image
                     ),
                     Span::with("", Modifier::Link | Modifier::LinkDescriptionWrapper),
+                    Span::with("", Modifier::Link | Modifier::LinkURLWrapper),
+                    Span::with("http://example.com", Modifier::Link | Modifier::LinkURL,),
+                    Span::with("", Modifier::Link | Modifier::LinkURLWrapper),
                 ],
                 kind: LineKind::Paragraph,
             }
@@ -1070,6 +1072,27 @@ I have searched far **and** wide but I have *yet* to come across a show that wou
                 ),],
                 kind: LineKind::Paragraph,
             }
+        );
+    }
+
+    #[test]
+    fn long_link_wrapping() {
+        let source = "blalalalallalabbalallalaa [![Packaging status](https://repology.org/badge/vertical-allrepos/mdfried.svg)](https://repology.org/project/mdfried/versions)";
+        let mut parser = make_parser();
+        let mut inline_parser = make_inline_parser();
+        let tree = parser.parse(source, None).unwrap();
+        let iter = MdIterator::new(tree, &mut inline_parser, source);
+
+        let line_iter = LineIterator::new(iter, 100, &DefaultMapper {});
+        let lines: Vec<Line> = line_iter.collect();
+        assert_eq!(
+            vec![
+                "blalalalallalabbalallalaa [![Packaging status](",
+                "https://repology.org/badge/vertical-allrepos/mdfried.svg)]",
+                "![Loading...](https://repology.org/badge/vertical-allrepos/mdfried.svg)",
+                "(https://repology.org/project/mdfried/versions)",
+            ],
+            Line::to_strings(&lines),
         );
     }
 }

--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -1105,6 +1105,7 @@ I have searched far **and** wide but I have *yet* to come across a show that wou
     }
 
     #[test]
+    #[ignore]
     fn long_url_link_wrapping() {
         let source = "[![Packaging status](https://repology.org/badge/vertical-allrepos/superloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongurl.svg)](https://repology.org/project/mdfried/versions)";
         let mut parser = make_parser();

--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -641,10 +641,18 @@ fn wrapped_to_lines<M: Mapper>(
                 .collect()
         };
 
-        let is_only_image = wrapped_line
-            .spans
-            .iter()
-            .all(|span| span.modifiers.contains(Modifier::Image));
+        // Really only replace an image line if it is just a full image on its own line.
+        // This excludes images that have been wrapped.
+        let is_only_image = wrapped_line.spans.len() == 5
+            && (wrapped_line.spans[0].modifiers == Modifier::Image
+                || wrapped_line.spans[0].modifiers == Modifier::Image | Modifier::NewLine)
+            && wrapped_line.spans[0].content == "!["
+            && wrapped_line.spans[1].modifiers == (Modifier::Image | Modifier::LinkDescription)
+            && wrapped_line.spans[2].modifiers == Modifier::Image
+            && wrapped_line.spans[2].content == "]("
+            && wrapped_line.spans[3].modifiers == (Modifier::Image | Modifier::LinkURL)
+            && wrapped_line.spans[4].modifiers == Modifier::Image
+            && wrapped_line.spans[4].content == ")";
         // Create text line
         if !is_only_image && !wrapped_line.spans.is_empty() {
             let mut spans = nesting_to_prefix_spans(line_nesting, mapper);
@@ -1076,7 +1084,7 @@ I have searched far **and** wide but I have *yet* to come across a show that wou
     }
 
     #[test]
-    fn long_link_wrapping() {
+    fn long_line_link_wrapping() {
         let source = "blalalalallalabbalallalaa [![Packaging status](https://repology.org/badge/vertical-allrepos/mdfried.svg)](https://repology.org/project/mdfried/versions)";
         let mut parser = make_parser();
         let mut inline_parser = make_inline_parser();
@@ -1092,6 +1100,43 @@ I have searched far **and** wide but I have *yet* to come across a show that wou
                 "![Loading...](https://repology.org/badge/vertical-allrepos/mdfried.svg)",
                 "(https://repology.org/project/mdfried/versions)",
             ],
+            Line::to_strings(&lines),
+        );
+    }
+
+    #[test]
+    fn long_url_link_wrapping() {
+        let source = "[![Packaging status](https://repology.org/badge/vertical-allrepos/superloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongurl.svg)](https://repology.org/project/mdfried/versions)";
+        let mut parser = make_parser();
+        let mut inline_parser = make_inline_parser();
+        let tree = parser.parse(source, None).unwrap();
+        let iter = MdIterator::new(tree, &mut inline_parser, source);
+
+        let line_iter = LineIterator::new(iter, 100, &DefaultMapper {});
+        let lines: Vec<Line> = line_iter.collect();
+        assert_eq!(
+            vec![
+                "[![Packaging status](",
+                "https://repology.org/badge/vertical-allrepos/superloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongurl.svg)]",
+                "![Loading...](https://repology.org/badge/vertical-allrepos/mdfried.svg)",
+                "(https://repology.org/project/mdfried/versions)",
+            ],
+            Line::to_strings(&lines),
+        );
+    }
+
+    #[test]
+    fn is_only_image() {
+        let source = "![image desc](https://image.com)";
+        let mut parser = make_parser();
+        let mut inline_parser = make_inline_parser();
+        let tree = parser.parse(source, None).unwrap();
+        let iter = MdIterator::new(tree, &mut inline_parser, source);
+
+        let line_iter = LineIterator::new(iter, 100, &DefaultMapper {});
+        let lines: Vec<Line> = line_iter.collect();
+        assert_eq!(
+            vec!["![image desc](https://image.com)"],
             Line::to_strings(&lines),
         );
     }

--- a/mdfrier/src/wrap.rs
+++ b/mdfrier/src/wrap.rs
@@ -80,6 +80,7 @@ pub fn wrap_md_spans(
         .collect()
 }
 
+// Also used by table cell wrapping.
 pub fn wrap_md_spans_lines(width: u16, mdspans: Vec<Span>, hide_urls: bool) -> Vec<Vec<Span>> {
     let mut lines: Vec<Vec<Span>> = Vec::new();
     let mut line: Vec<Span> = Vec::new();
@@ -113,7 +114,23 @@ pub fn wrap_md_spans_lines(width: u16, mdspans: Vec<Span>, hide_urls: bool) -> V
             .filter(|span| !hide_urls || !span.modifiers.is_link_url())
             .map(UnicodeWidthStr::width)
             .sum::<usize>() as u16;
-        let would_overflow = line_width + span_width > width;
+        let mut would_overflow = line_width + span_width > width;
+        if would_overflow && mdspan.modifiers.contains(Modifier::LinkURL) {
+            let move_paren = line.last().is_some_and(|last| {
+                last.modifiers.contains(Modifier::LinkURLWrapper) && last.content == "("
+            });
+            if move_paren && let Some(paren) = line.pop() {
+                lines.push(std::mem::take(&mut line));
+                line.push(paren);
+                line_width = 1;
+            } else {
+                // The last span was not "(", could be a fused "](" from an image.
+                // Ignore but do move this LinkURL into its own line to try to avoid breaking.
+                lines.push(std::mem::take(&mut line));
+                line_width = 0;
+            }
+            would_overflow = line_width + span_width > width;
+        }
         if would_overflow {
             // Noe: this *was* something weird about moving links that would exceed `width`
             // together with their surrounding parens.
@@ -270,7 +287,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     // We are not doing the special "don't break URLs but move the surrounding parens into the URL
     // line" anymore.
     fn link_wrapping() {

--- a/mdfrier/src/wrap.rs
+++ b/mdfrier/src/wrap.rs
@@ -146,7 +146,8 @@ pub fn wrap_md_spans_lines(width: u16, mdspans: Vec<Span>, hide_urls: bool) -> V
                 continue;
             };
             let first_content = first_part.as_ref();
-            line.push(Span::new(first_content.to_owned(), mdspan.modifiers));
+            let first_span = Span::new(first_content.to_owned(), mdspan.modifiers);
+            line.push(first_span);
             lines.push(std::mem::take(&mut line));
             line_width = 0;
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -420,8 +420,8 @@ pub enum FindTarget {
 impl FindTarget {
     fn matches(&self, extra: &LineExtra) -> bool {
         match self {
-            FindTarget::Link => matches!(extra, LineExtra::Link(_, _, _)),
-            FindTarget::Search => matches!(extra, LineExtra::SearchMatch(_, _, _)),
+            FindTarget::Link => matches!(extra, LineExtra::Link(..)),
+            FindTarget::Search => matches!(extra, LineExtra::SearchMatch(..)),
         }
     }
 }
@@ -573,15 +573,26 @@ impl Display for Section {
 }
 
 pub enum LineExtra {
-    Link(SourceContent, u16, u16),
+    /// URL, start, end, multiline_count
+    ///
+    /// The "multiline_count" means "how many lines up does the link actually start".
+    Link(SourceContent, u16, u16, Option<usize>),
+    /// start, end, text
     SearchMatch(usize, usize, String),
 }
 
 impl Debug for LineExtra {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LineExtra::Link(url, start, end) => {
-                write!(f, "Link({:?}, {}, {})", url, start, end)
+            LineExtra::Link(url, start, end, lines) => {
+                write!(
+                    f,
+                    "Link({:?}, {}, {}, {})",
+                    url,
+                    start,
+                    end,
+                    lines.unwrap_or_default()
+                )
             }
             LineExtra::SearchMatch(start, end, text) => {
                 write!(f, "SearchMatch({}, {}, {:?})", start, end, text)
@@ -594,8 +605,8 @@ impl Debug for LineExtra {
 impl PartialEq for LineExtra {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (LineExtra::Link(l0, l1, l2), LineExtra::Link(r0, r1, r2)) => {
-                l0 == r0 && l1 == r1 && l2 == r2
+            (LineExtra::Link(l0, l1, l2, l3), LineExtra::Link(r0, r1, r2, r3)) => {
+                l0 == r0 && l1 == r1 && l2 == r2 && l3 == r3
             }
             (LineExtra::SearchMatch(l0, l1, l2), LineExtra::SearchMatch(r0, r1, r2)) => {
                 l0 == r0 && l1 == r1 && l2 == r2

--- a/src/document.rs
+++ b/src/document.rs
@@ -941,6 +941,15 @@ mod tests {
         *,
     };
 
+    #[ctor::ctor]
+    fn init_logger() {
+        #[expect(clippy::let_underscore_untyped, clippy::unwrap_used)]
+        let _ = flexi_logger::Logger::try_with_env()
+            .unwrap()
+            .start()
+            .inspect_err(|err| eprint!("test logger setup failed: {err}"));
+    }
+
     #[test]
     fn widgestsources_update() {
         let mut ws = Document::default();
@@ -1019,12 +1028,6 @@ mod tests {
     #[test]
     #[expect(clippy::unwrap_used)]
     fn get_y() {
-        #[expect(clippy::let_underscore_untyped)]
-        let _ = flexi_logger::Logger::try_with_env()
-            .unwrap()
-            .start()
-            .inspect_err(|err| eprint!("test logger setup failed: {err}"));
-
         let mut doc = Document::default();
         doc.push(Section {
             id: 1,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -210,7 +210,7 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
                         for (_, extras) in lines {
                             if remaining < extras.len() {
                                 return match &extras[remaining] {
-                                    LineExtra::Link(url, _, _) => Some(url.clone()),
+                                    LineExtra::Link(url, ..) => Some(url.clone()),
                                     _ => None,
                                 };
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,13 +406,16 @@ mod tests {
         worker::worker_thread,
     };
 
-    fn setup(config: Config) -> (Model, JoinHandle<Result<(), Error>>, Size) {
-        #[expect(clippy::let_underscore_untyped)]
+    #[ctor::ctor]
+    fn init_logger() {
+        #[expect(clippy::let_underscore_untyped, clippy::unwrap_used)]
         let _ = flexi_logger::Logger::try_with_env()
             .unwrap()
             .start()
             .inspect_err(|err| eprint!("test logger setup failed: {err}"));
+    }
 
+    fn setup(config: Config) -> (Model, JoinHandle<Result<(), Error>>, Size) {
         let (cmd_tx, cmd_rx) = mpsc::channel::<Cmd>();
         let (event_tx, event_rx) = mpsc::channel::<Event>();
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -339,7 +339,7 @@ impl Model {
                 let mut remaining = pointer.index;
                 for (_, extras) in lines {
                     if remaining < extras.len() {
-                        let LineExtra::Link(url, _, _) = &extras[remaining] else {
+                        let LineExtra::Link(url, ..) = &extras[remaining] else {
                             return None;
                         };
                         return Some(url.clone());
@@ -625,8 +625,8 @@ mod tests {
             content: SectionContent::Lines(vec![(
                 Line::from("http://a.com http://b.com"),
                 vec![
-                    LineExtra::Link(link_a.clone(), 0, 11),
-                    LineExtra::Link(link_b.clone(), 12, 21),
+                    LineExtra::Link(link_a.clone(), 0, 11, None),
+                    LineExtra::Link(link_b.clone(), 12, 21, None),
                 ],
             )]),
         });
@@ -635,7 +635,7 @@ mod tests {
             height: 1,
             content: SectionContent::Lines(vec![(
                 Line::from("http://c.com"),
-                vec![LineExtra::Link(link_c.clone(), 0, 11)],
+                vec![LineExtra::Link(link_c.clone(), 0, 11, None)],
             )]),
         });
 
@@ -662,7 +662,7 @@ mod tests {
                 height: 1,
                 content: SectionContent::Lines(vec![(
                     Line::from(url.clone()),
-                    vec![LineExtra::Link(link, 0, 11)],
+                    vec![LineExtra::Link(link, 0, 11, None)],
                 )]),
             });
         }
@@ -681,7 +681,7 @@ mod tests {
             height: 1,
             content: SectionContent::Lines(vec![(
                 Line::from("http://a.com"),
-                vec![LineExtra::Link(link.clone(), 0, 11)],
+                vec![LineExtra::Link(link.clone(), 0, 11, None)],
             )]),
         });
         for i in 2..5 {
@@ -709,8 +709,8 @@ mod tests {
             content: SectionContent::Lines(vec![(
                 Line::from("http://a.com http://b.com"),
                 vec![
-                    LineExtra::Link(link_a.clone(), 0, 11),
-                    LineExtra::Link(link_b.clone(), 12, 21),
+                    LineExtra::Link(link_a.clone(), 0, 11, None),
+                    LineExtra::Link(link_b.clone(), 12, 21, None),
                 ],
             )]),
         });
@@ -719,7 +719,7 @@ mod tests {
             height: 1,
             content: SectionContent::Lines(vec![(
                 Line::from("http://c.com"),
-                vec![LineExtra::Link(link_c.clone(), 0, 11)],
+                vec![LineExtra::Link(link_c.clone(), 0, 11, None)],
             )]),
         });
 
@@ -745,8 +745,8 @@ mod tests {
             content: SectionContent::Lines(vec![(
                 Line::from("http://a.com http://b.com"),
                 vec![
-                    LineExtra::Link(link_a.clone(), 0, 11),
-                    LineExtra::Link(link_b.clone(), 12, 21),
+                    LineExtra::Link(link_a.clone(), 0, 11, None),
+                    LineExtra::Link(link_b.clone(), 12, 21, None),
                 ],
             )]),
         });
@@ -755,7 +755,7 @@ mod tests {
             height: 1,
             content: SectionContent::Lines(vec![(
                 Line::from("http://c.com"),
-                vec![LineExtra::Link(link_c.clone(), 0, 11)],
+                vec![LineExtra::Link(link_c.clone(), 0, 11, None)],
             )]),
         });
 
@@ -834,7 +834,7 @@ mod tests {
             height: 1,
             content: SectionContent::Lines(vec![(
                 Line::from("http://a.com"),
-                vec![LineExtra::Link(link.clone(), 0, 11)],
+                vec![LineExtra::Link(link.clone(), 0, 11, None)],
             )]),
         });
 
@@ -857,7 +857,7 @@ mod tests {
         let SectionContent::Lines(lines) = &last_rendered.content else {
             panic!("expected Line");
         };
-        let LineExtra::Link(url, _, _) = &lines[0].1[0] else {
+        let LineExtra::Link(url, ..) = &lines[0].1[0] else {
             panic!("expected Link");
         };
         assert_eq!("http://a.com", url.as_ref());
@@ -875,7 +875,7 @@ mod tests {
                 height: 1,
                 content: SectionContent::Lines(vec![(
                     Line::from(url),
-                    vec![LineExtra::Link(link.clone(), 0, 11)],
+                    vec![LineExtra::Link(link.clone(), 0, 11, None)],
                 )]),
             });
             links.push(link);

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,8 +3,8 @@ use unicode_width::UnicodeWidthStr as _;
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Stylize as _},
-    text::{Line, Span, Text},
+    style::{Color, Stylize},
+    text::{Line, Span},
     widgets::{Block, Paragraph, Widget},
 };
 
@@ -80,62 +80,25 @@ pub fn view(model: &Model, frame: &mut Frame) {
                             for (i, extra) in extras.iter().enumerate() {
                                 if let LineExtra::Link(url, start, end, lines_count) = extra {
                                     if url.as_ptr() == selected.as_ptr() {
-                                        let start = if let Some(previous_lines_count) = lines_count
-                                            && *previous_lines_count > 0
-                                        {
-                                            for previous_lines_idx in
-                                                (0..*previous_lines_count).rev()
-                                            {
-                                                let max_line_end =
-                                                    model.inner_width(frame_area.width);
-                                                let (start, end) = if previous_lines_idx == 0 {
-                                                    (*start, max_line_end)
-                                                } else {
-                                                    (0, max_line_end)
-                                                };
-
-                                                let previous_line_y =
-                                                    if previous_lines_idx as i32 >= y {
-                                                        break;
-                                                    } else {
-                                                        (y - (previous_lines_idx as i32 + 1)) as u16
-                                                    };
-
-                                                let Some(previous_line) = line_idx
-                                                    .checked_sub(previous_lines_idx)
-                                                    .and_then(|i| lines.get(i))
-                                                else {
-                                                    log::error!(
-                                                        "LineExtra::Link with multiline out of bounds"
-                                                    );
-                                                    break;
-                                                };
-                                                let display_text = extract_line_content(
-                                                    &previous_line.0,
-                                                    start,
-                                                    end,
-                                                );
-                                                let (link_overlay, width) =
-                                                    link_overlay_widget(start, end, display_text);
-                                                let x = frame_area.x + padding.left + start;
-                                                let area = Rect::new(x, previous_line_y, width, 1);
-                                                frame.render_widget(link_overlay, area);
-                                            }
-                                            0
-                                        } else {
-                                            *start
-                                        };
-
-                                        let display_text = extract_line_content(line, start, *end);
-                                        let (link_overlay, width) =
-                                            link_overlay_widget(start, *end, display_text);
-                                        let x = frame_area.x + padding.left + start;
-                                        let area = Rect::new(x, line_y, width, 1);
-                                        frame.render_widget(link_overlay, area);
-
+                                        let mut last_start = 0;
+                                        for (link_overlay, area) in link_overlays(
+                                            line,
+                                            *start,
+                                            *end,
+                                            lines_count,
+                                            line_idx,
+                                            lines,
+                                            padding.left,
+                                            model.inner_width(frame_area.width),
+                                            line_y,
+                                            frame.area(),
+                                        ) {
+                                            frame.render_widget(link_overlay, area);
+                                            last_start = area.x;
+                                        }
                                         // Position cursor on the actual selected link
                                         if *id == section.id && *index == flat_index + i {
-                                            cursor_positioned = Some((x, line_y));
+                                            cursor_positioned = Some((last_start, line_y));
                                         }
                                     }
                                 }
@@ -303,11 +266,69 @@ fn render_lines<W: Widget>(widget: W, source_height: u16, y: u16, area: Rect, f:
     f.render_widget(widget, widget_area);
 }
 
-fn link_overlay_widget<'a, T: Into<Text<'a>>>(
+#[expect(clippy::too_many_arguments)]
+fn link_overlays<'a>(
+    line: &Line<'a>,
     start: u16,
     end: u16,
-    display_text: T,
-) -> (Paragraph<'a>, u16) {
+    lines_count: &Option<usize>,
+    line_idx: usize,
+    lines: &[(Line<'a>, Vec<LineExtra>)],
+    padding_left: u16,
+    max_line_end: u16,
+    line_y: u16,
+    frame_area: Rect,
+) -> Vec<(Paragraph<'a>, Rect)> {
+    let mut overlays = Vec::new();
+
+    let start = if let Some(previous_lines_count) = lines_count
+        && *previous_lines_count > 0
+    {
+        for previous_lines_idx in (0..*previous_lines_count).rev() {
+            let (start, end) = if previous_lines_idx == previous_lines_count - 1 {
+                (start, max_line_end)
+            } else {
+                (0, max_line_end)
+            };
+
+            let previous_line_y = if previous_lines_idx as u16 >= line_y {
+                break;
+            } else {
+                line_y - (previous_lines_idx as u16 + 1)
+            };
+
+            let Some(previous_line) = line_idx
+                .checked_sub(previous_lines_idx + 1)
+                .and_then(|i| lines.get(i))
+            else {
+                log::error!("LineExtra::Link with multiline out of bounds");
+                break;
+            };
+            let display_text = extract_line_content(&previous_line.0, start, end);
+            let (link_overlay, width) = link_overlay_widget(start, end, display_text);
+            let x = frame_area.x + padding_left + start;
+            let area = Rect::new(x, previous_line_y, width, 1);
+            overlays.push((link_overlay, area));
+        }
+        0
+    } else {
+        start
+    };
+
+    if !(start == 0 && end == 0) {
+        // Links may end at 0-0 if the closing bracket "]" is at the beginning of a line.
+        // Just skip the overlay, although that line is the "anchor" for other purposes.
+        let display_text = extract_line_content(line, start, end);
+        let (link_overlay, width) = link_overlay_widget(start, end, display_text);
+        let x = frame_area.x + padding_left + start;
+        let area = Rect::new(x, line_y, width, 1);
+        overlays.push((link_overlay, area));
+    }
+
+    overlays
+}
+
+fn link_overlay_widget<'a>(start: u16, end: u16, display_text: Line<'a>) -> (Paragraph<'a>, u16) {
     let width = end - start;
     let link_overlay = Paragraph::new(display_text)
         .fg(Color::Indexed(15))
@@ -317,13 +338,19 @@ fn link_overlay_widget<'a, T: Into<Text<'a>>>(
 
 /// Extract text content from a Line.
 /// The start and end positions must be exactly at the boundaries of the spans.
-fn extract_line_content(line: &Line, start: u16, end: u16) -> String {
-    debug_assert!(end > start, "extract_line_content expects start > end");
+fn extract_line_content<'a>(line: &Line<'a>, start: u16, end: u16) -> Line<'a> {
+    debug_assert!(
+        end > start,
+        "extract_line_content expects start > end: {start}-{end}"
+    );
     let mut pos: u16 = 0;
-    let mut content = String::new();
+    let mut content = Line::default();
     for span in &line.spans {
         if pos >= start {
-            content.push_str(&span.content);
+            let mut link_span = span.clone();
+            link_span.style.fg = None;
+            link_span.style.bg = None;
+            content.push_span(link_span);
         }
 
         let span_width = span.content.width() as u16;
@@ -334,4 +361,62 @@ fn extract_line_content(line: &Line, start: u16, end: u16) -> String {
         }
     }
     content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn simple_link_overlays() {
+        let lines = vec![
+            (
+                Line::from(vec![Span::from("prefix "), Span::from("link desc")]),
+                vec![],
+            ),
+            (
+                Line::from(vec![Span::from("link cont"), Span::from(" suffix")]),
+                vec![],
+            ),
+        ];
+        let start = 7;
+        let end = 9;
+        let lines_count = Some(1);
+        let line_idx = 1;
+        let line = &lines[line_idx].0;
+        let padding_left = 10;
+        let max_line_end = 100;
+        let line_y = 1;
+        let frame_area = Rect::new(0, 0, 120, 50);
+        let overlays = link_overlays(
+            line,
+            start,
+            end,
+            &lines_count,
+            line_idx,
+            &lines,
+            padding_left,
+            max_line_end,
+            line_y,
+            frame_area,
+        );
+        assert_eq!(
+            overlays,
+            vec![
+                (
+                    Paragraph::new(Line::from(Span::from("link desc")))
+                        .fg(Color::Indexed(15))
+                        .bg(Color::Indexed(32)),
+                    Rect::new(17, 0, 93, 1)
+                ),
+                (
+                    Paragraph::new(Line::from(Span::from("link cont")))
+                        .fg(Color::Indexed(15))
+                        .bg(Color::Indexed(32)),
+                    Rect::new(10, 1, 9, 1)
+                )
+            ]
+        );
+    }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,7 +3,7 @@ use unicode_width::UnicodeWidthStr as _;
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Stylize},
+    style::{Color, Stylize as _},
     text::{Line, Span},
     widgets::{Block, Paragraph, Widget},
 };

--- a/src/view.rs
+++ b/src/view.rs
@@ -4,7 +4,7 @@ use ratatui::{
     Frame,
     layout::Rect,
     style::{Color, Stylize as _},
-    text::{Line, Span},
+    text::{Line, Span, Text},
     widgets::{Block, Paragraph, Widget},
 };
 
@@ -57,7 +57,7 @@ pub fn view(model: &Model, frame: &mut Frame) {
         match &section.content {
             SectionContent::Lines(lines) => {
                 let mut flat_index = 0;
-                for (line, extras) in lines.iter() {
+                for (line_idx, (line, extras)) in lines.iter().enumerate() {
                     const LINE_HEIGHT: u16 = 1;
 
                     if y < 0 {
@@ -78,17 +78,60 @@ pub fn view(model: &Model, frame: &mut Frame) {
                     if let Cursor::Links(CursorPointer { id, index }) = &model.cursor {
                         if let Some(selected) = &selected_url {
                             for (i, extra) in extras.iter().enumerate() {
-                                if let LineExtra::Link(url, start, end) = extra {
+                                if let LineExtra::Link(url, start, end, lines_count) = extra {
                                     if url.as_ptr() == selected.as_ptr() {
-                                        let x = frame_area.x + padding.left + *start;
-                                        let width = end - start;
+                                        let start = if let Some(previous_lines_count) = lines_count
+                                            && *previous_lines_count > 0
+                                        {
+                                            for previous_lines_idx in
+                                                (0..*previous_lines_count).rev()
+                                            {
+                                                let max_line_end =
+                                                    model.inner_width(frame_area.width);
+                                                let (start, end) = if previous_lines_idx == 0 {
+                                                    (*start, max_line_end)
+                                                } else {
+                                                    (0, max_line_end)
+                                                };
+
+                                                let previous_line_y =
+                                                    if previous_lines_idx as i32 >= y {
+                                                        break;
+                                                    } else {
+                                                        (y - (previous_lines_idx as i32 + 1)) as u16
+                                                    };
+
+                                                let Some(previous_line) = line_idx
+                                                    .checked_sub(previous_lines_idx)
+                                                    .and_then(|i| lines.get(i))
+                                                else {
+                                                    log::error!(
+                                                        "LineExtra::Link with multiline out of bounds"
+                                                    );
+                                                    break;
+                                                };
+                                                let display_text = extract_line_content(
+                                                    &previous_line.0,
+                                                    start,
+                                                    end,
+                                                );
+                                                let (link_overlay, width) =
+                                                    link_overlay_widget(start, end, display_text);
+                                                let x = frame_area.x + padding.left + start;
+                                                let area = Rect::new(x, previous_line_y, width, 1);
+                                                frame.render_widget(link_overlay, area);
+                                            }
+                                            0
+                                        } else {
+                                            *start
+                                        };
+
+                                        let display_text = extract_line_content(line, start, *end);
+                                        let (link_overlay, width) =
+                                            link_overlay_widget(start, *end, display_text);
+                                        let x = frame_area.x + padding.left + start;
                                         let area = Rect::new(x, line_y, width, 1);
-                                        // Highlight with original content - source_content is only for grouping/opening
-                                        let display_text = extract_line_content(line, *start);
-                                        let link_overlay_widget = Paragraph::new(display_text)
-                                            .fg(Color::Indexed(15))
-                                            .bg(Color::Indexed(32));
-                                        frame.render_widget(link_overlay_widget, area);
+                                        frame.render_widget(link_overlay, area);
 
                                         // Position cursor on the actual selected link
                                         if *id == section.id && *index == flat_index + i {
@@ -104,17 +147,21 @@ pub fn view(model: &Model, frame: &mut Frame) {
                                 let x = frame_area.x + padding.left + (*start as u16);
                                 let width = *end as u16 - *start as u16;
                                 let area = Rect::new(x, line_y, width, 1);
-                                let mut link_overlay_widget = Paragraph::new(text.clone());
-                                link_overlay_widget = if let Some(CursorPointer { id, index }) =
+                                let mut search_highlight_overlay = Paragraph::new(text.clone());
+                                search_highlight_overlay = if let Some(CursorPointer { id, index }) =
                                     pointer
                                     && section.id == *id
                                     && flat_index + i == *index
                                 {
-                                    link_overlay_widget.fg(Color::Black).bg(Color::Indexed(197))
+                                    search_highlight_overlay
+                                        .fg(Color::Black)
+                                        .bg(Color::Indexed(197))
                                 } else {
-                                    link_overlay_widget.fg(Color::Black).bg(Color::Indexed(148))
+                                    search_highlight_overlay
+                                        .fg(Color::Black)
+                                        .bg(Color::Indexed(148))
                                 };
-                                frame.render_widget(link_overlay_widget, area);
+                                frame.render_widget(search_highlight_overlay, area);
                                 cursor_positioned = Some((x, line_y));
                             }
                         }
@@ -256,20 +303,35 @@ fn render_lines<W: Widget>(widget: W, source_height: u16, y: u16, area: Rect, f:
     f.render_widget(widget, widget_area);
 }
 
-/// Extract text content from a Line at a given character position.
-/// Each LineExtra::Link corresponds to exactly one span, so we find the span starting at `start`.
-fn extract_line_content(line: &Line, start: u16) -> String {
+fn link_overlay_widget<'a, T: Into<Text<'a>>>(
+    start: u16,
+    end: u16,
+    display_text: T,
+) -> (Paragraph<'a>, u16) {
+    let width = end - start;
+    let link_overlay = Paragraph::new(display_text)
+        .fg(Color::Indexed(15))
+        .bg(Color::Indexed(32));
+    (link_overlay, width)
+}
+
+/// Extract text content from a Line.
+/// The start and end positions must be exactly at the boundaries of the spans.
+fn extract_line_content(line: &Line, start: u16, end: u16) -> String {
+    debug_assert!(end > start, "extract_line_content expects start > end");
     let mut pos: u16 = 0;
+    let mut content = String::new();
     for span in &line.spans {
-        if pos == start {
-            return span.content.to_string();
+        if pos >= start {
+            content.push_str(&span.content);
         }
+
         let span_width = span.content.width() as u16;
         pos += span_width;
-        if pos > start {
-            // We passed the start position without finding an exact match
+
+        if pos >= end {
             break;
         }
     }
-    String::new()
+    content
 }

--- a/src/worker/link_tracker.rs
+++ b/src/worker/link_tracker.rs
@@ -169,4 +169,10 @@ mod tests {
             LineExtra::Link(SourceContent::from("url"), 1, 20)
         );
     }
+
+    #[test]
+    #[ignore]
+    fn track_wrapped_link() {
+        // TODO: let LinkTracker operate on multiple lines.
+    }
 }

--- a/src/worker/link_tracker.rs
+++ b/src/worker/link_tracker.rs
@@ -12,24 +12,54 @@ use crate::document::LineExtra;
 /// where "start" and "end" are the respective positions in the [`mdfrier::Line`].
 pub struct LinkTracker {
     offset: u16,
+    // line_count: usize,
     extras: Vec<LineExtra>,
     link_builder: LinkExtraLinkBuilder,
+    debug: bool,
 }
 
 #[derive(Debug, Default, PartialEq)]
 enum LinkExtraLinkBuilder {
     #[default]
     None,
-    Start(u16),
-    StartEnd(u16, u16),
-    StartEndUrl(u16, u16, String),
+    Start {
+        start: u16,
+        lines: usize,
+    },
+    StartEnd {
+        start: u16,
+        end: u16,
+        lines: usize,
+    },
+    StartEndUrl {
+        start: u16,
+        end: u16,
+        lines: usize,
+        url: String,
+    },
 }
 
 impl LinkTracker {
+    pub fn debug() -> LinkTracker {
+        LinkTracker {
+            debug: true,
+            ..Default::default()
+        }
+    }
     pub fn carriage_return(&mut self) {
+        if self.debug {
+            log::debug!("carriage_return on: {:?}", self.link_builder);
+        }
         self.offset = 0;
+        // Only increase line count if we haven't reached "end" yet.
+        if let LinkExtraLinkBuilder::Start { lines, .. } = &mut self.link_builder {
+            *lines += 1;
+        }
     }
     pub fn track(&mut self, node: &mdfrier::Span) {
+        if self.debug {
+            log::debug!("track: {:?}", node.modifiers);
+        }
         let span_width = node.content.width() as u16;
         if self.link_builder == LinkExtraLinkBuilder::None
             && node
@@ -37,51 +67,73 @@ impl LinkTracker {
                 .is_link_modifier(MdModifier::LinkDescriptionWrapper)
         {
             // Enter link description at next span.
-            self.link_builder = LinkExtraLinkBuilder::Start(self.offset + span_width);
-        } else if let LinkExtraLinkBuilder::Start(start) = self.link_builder
+            self.link_builder = LinkExtraLinkBuilder::Start {
+                start: self.offset + span_width,
+                lines: 0,
+            };
+        } else if let LinkExtraLinkBuilder::Start { start, lines } = self.link_builder
             && node
                 .modifiers
                 .is_link_modifier(MdModifier::LinkDescriptionWrapper)
         {
             // Exit link description before this span.
-            if self.offset > start {
-                self.link_builder = LinkExtraLinkBuilder::StartEnd(start, self.offset);
-            } else {
-                log::error!("LinkExtraLinkBuilder::Start(start) > offset");
-                // TODO: this needs fixing!
-                self.link_builder = LinkExtraLinkBuilder::None;
-            }
-        } else if let LinkExtraLinkBuilder::StartEnd(start, end) = self.link_builder
+            self.link_builder = LinkExtraLinkBuilder::StartEnd {
+                start,
+                end: self.offset,
+                lines,
+            };
+        } else if let LinkExtraLinkBuilder::StartEnd { start, end, lines } = self.link_builder
             && node.modifiers.is_link_modifier(MdModifier::LinkURLWrapper)
         {
             // Enter link URL next span.
-            self.link_builder = LinkExtraLinkBuilder::StartEndUrl(start, end, String::new());
-        } else if let LinkExtraLinkBuilder::StartEndUrl(_, _, url) = &mut self.link_builder
+            self.link_builder = LinkExtraLinkBuilder::StartEndUrl {
+                start,
+                end,
+                lines,
+                url: String::new(),
+            };
+        } else if let LinkExtraLinkBuilder::StartEndUrl { url, .. } = &mut self.link_builder
             && node.modifiers.is_link_url()
         {
             // Push all LinkURL spans into URL.
             url.push_str(&node.content);
         } else if node.modifiers.is_link_modifier(MdModifier::LinkURLWrapper)
-            && matches!(
-                self.link_builder,
-                LinkExtraLinkBuilder::StartEndUrl(_, _, _)
-            )
+            && matches!(self.link_builder, LinkExtraLinkBuilder::StartEndUrl { .. })
         {
-            let LinkExtraLinkBuilder::StartEndUrl(start, end, url) =
-                std::mem::take(&mut self.link_builder)
+            let LinkExtraLinkBuilder::StartEndUrl {
+                start,
+                end,
+                lines,
+                url,
+            } = std::mem::take(&mut self.link_builder)
             else {
+                // We need to "take if matches", so we can't put the destructure in the `if` above.
                 unreachable!("invariant by matches macro");
             };
             // Exit URL, can build the LinkExtra::Link now.
-            self.extras
-                .push(LineExtra::Link(SourceContent::from(&*url), start, end));
+            self.exit(start, end, lines, url.as_str());
         }
         self.offset += span_width;
+
+        if self.debug {
+            log::debug!("state: {:?}", self.link_builder);
+        }
     }
     pub fn extras(&mut self) -> Vec<LineExtra> {
         let mut extras = Vec::new();
         swap(&mut self.extras, &mut extras);
+        if self.debug {
+            log::debug!("extras: {extras:?}");
+        }
         extras
+    }
+    fn exit(&mut self, start: u16, end: u16, lines: usize, url: &str) {
+        if self.debug {
+            log::debug!("exit: {start}-{end}, {url}");
+        }
+        let lines = if lines == 0 { None } else { Some(lines) };
+        self.extras
+            .push(LineExtra::Link(SourceContent::from(url), start, end, lines));
     }
 }
 
@@ -90,6 +142,15 @@ mod tests {
     use super::*;
     use mdfrier::Span;
     use pretty_assertions::assert_eq;
+
+    #[ctor::ctor]
+    fn init_logger() {
+        #[expect(clippy::let_underscore_untyped, clippy::unwrap_used)]
+        let _ = flexi_logger::Logger::try_with_env()
+            .unwrap()
+            .start()
+            .inspect_err(|err| eprint!("test logger setup failed: {err}"));
+    }
 
     fn test_link(description: &str, url: &str) -> Vec<Span> {
         vec![
@@ -119,17 +180,20 @@ mod tests {
 
     #[test]
     fn track_link() {
-        let mut tracker = LinkTracker::default();
+        let mut tracker = LinkTracker::debug();
         for span in test_link("desc", "url") {
             tracker.track(&span);
         }
         let extras = tracker.extras();
-        assert_eq!(extras[0], LineExtra::Link(SourceContent::from("url"), 1, 5));
+        assert_eq!(
+            extras[0],
+            LineExtra::Link(SourceContent::from("url"), 1, 5, None)
+        );
     }
 
     #[test]
     fn track_nested_image() {
-        let mut tracker = LinkTracker::default();
+        let mut tracker = LinkTracker::debug();
         let mut spans = test_link("desc", "url");
         spans.splice(
             1..2,
@@ -166,13 +230,119 @@ mod tests {
         let extras = tracker.extras();
         assert_eq!(
             extras[0],
-            LineExtra::Link(SourceContent::from("url"), 1, 20)
+            LineExtra::Link(SourceContent::from("url"), 1, 20, None)
         );
     }
 
     #[test]
-    #[ignore]
     fn track_wrapped_link() {
-        // TODO: let LinkTracker operate on multiple lines.
+        let mut tracker = LinkTracker::debug();
+
+        tracker.track(&Span::new(
+            "[".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescriptionWrapper,
+        ));
+        tracker.track(&Span::new(
+            "desc".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescription,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "cont".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescription,
+        ));
+        tracker.track(&Span::new(
+            "]".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescriptionWrapper,
+        ));
+        tracker.track(&Span::new(
+            "(".to_owned(),
+            MdModifier::Link | MdModifier::LinkURLWrapper,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "url".to_owned(),
+            MdModifier::Link | MdModifier::LinkURL,
+        ));
+        tracker.track(&Span::new(
+            ")".to_owned(),
+            MdModifier::Link | MdModifier::LinkURLWrapper,
+        ));
+
+        let extras = tracker.extras();
+        assert_eq!(
+            extras[0],
+            LineExtra::Link(SourceContent::from("url"), 1, 4, Some(1)),
+        );
+    }
+
+    #[test]
+    fn track_multiple_wraps_link() {
+        let mut tracker = LinkTracker::debug();
+
+        tracker.track(&Span::new("nothing ".to_owned(), MdModifier::default()));
+
+        tracker.track(&Span::new(
+            "[".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescriptionWrapper,
+        ));
+        tracker.track(&Span::new(
+            "desc1".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescription,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "desc2".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescription,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "desc3".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescription,
+        ));
+
+        tracker.track(&Span::new(
+            "]".to_owned(),
+            MdModifier::Link | MdModifier::LinkDescriptionWrapper,
+        ));
+        tracker.track(&Span::new(
+            "(".to_owned(),
+            MdModifier::Link | MdModifier::LinkURLWrapper,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "url-1/".to_owned(),
+            MdModifier::Link | MdModifier::LinkURL,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            "url-2".to_owned(),
+            MdModifier::Link | MdModifier::LinkURL,
+        ));
+        tracker.carriage_return();
+
+        tracker.track(&Span::new(
+            ")".to_owned(),
+            MdModifier::Link | MdModifier::LinkURLWrapper,
+        ));
+
+        let extras = tracker.extras();
+        // ```
+        // nothing [desc1
+        // desc2
+        // desc3]
+        // ```
+        // So we want: start at "[" 9, end at "]" 5, two lines "up", and correct URL
+        // reconstruction.
+        assert_eq!(
+            extras[0],
+            LineExtra::Link(SourceContent::from("url-1/url-2"), 9, 5, Some(2)),
+        );
     }
 }

--- a/src/worker/link_tracker.rs
+++ b/src/worker/link_tracker.rs
@@ -15,7 +15,7 @@ pub struct LinkTracker {
     // line_count: usize,
     extras: Vec<LineExtra>,
     link_builder: LinkExtraLinkBuilder,
-    debug: bool,
+    hide_urls: bool,
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -40,16 +40,12 @@ enum LinkExtraLinkBuilder {
 }
 
 impl LinkTracker {
-    pub fn debug() -> LinkTracker {
-        LinkTracker {
-            debug: true,
-            ..Default::default()
-        }
+    pub fn hide_urls(mut self, hide_urls: bool) -> LinkTracker {
+        self.hide_urls = hide_urls;
+        self
     }
+
     pub fn carriage_return(&mut self) {
-        if self.debug {
-            log::debug!("carriage_return on: {:?}", self.link_builder);
-        }
         self.offset = 0;
         // Only increase line count if we haven't reached "end" yet.
         if let LinkExtraLinkBuilder::Start { lines, .. } = &mut self.link_builder {
@@ -57,9 +53,6 @@ impl LinkTracker {
         }
     }
     pub fn track(&mut self, node: &mdfrier::Span) {
-        if self.debug {
-            log::debug!("track: {:?}", node.modifiers);
-        }
         let span_width = node.content.width() as u16;
         if self.link_builder == LinkExtraLinkBuilder::None
             && node
@@ -113,24 +106,20 @@ impl LinkTracker {
             // Exit URL, can build the LinkExtra::Link now.
             self.exit(start, end, lines, url.as_str());
         }
-        self.offset += span_width;
-
-        if self.debug {
-            log::debug!("state: {:?}", self.link_builder);
+        if self.hide_urls {
+            if !node.modifiers.is_link_url() {
+                self.offset += span_width;
+            }
+        } else {
+            self.offset += span_width;
         }
     }
     pub fn extras(&mut self) -> Vec<LineExtra> {
         let mut extras = Vec::new();
         swap(&mut self.extras, &mut extras);
-        if self.debug {
-            log::debug!("extras: {extras:?}");
-        }
         extras
     }
     fn exit(&mut self, start: u16, end: u16, lines: usize, url: &str) {
-        if self.debug {
-            log::debug!("exit: {start}-{end}, {url}");
-        }
         let lines = if lines == 0 { None } else { Some(lines) };
         self.extras
             .push(LineExtra::Link(SourceContent::from(url), start, end, lines));
@@ -180,7 +169,7 @@ mod tests {
 
     #[test]
     fn track_link() {
-        let mut tracker = LinkTracker::debug();
+        let mut tracker = LinkTracker::default();
         for span in test_link("desc", "url") {
             tracker.track(&span);
         }
@@ -193,7 +182,7 @@ mod tests {
 
     #[test]
     fn track_nested_image() {
-        let mut tracker = LinkTracker::debug();
+        let mut tracker = LinkTracker::default();
         let mut spans = test_link("desc", "url");
         spans.splice(
             1..2,
@@ -236,7 +225,7 @@ mod tests {
 
     #[test]
     fn track_wrapped_link() {
-        let mut tracker = LinkTracker::debug();
+        let mut tracker = LinkTracker::default();
 
         tracker.track(&Span::new(
             "[".to_owned(),
@@ -280,7 +269,7 @@ mod tests {
 
     #[test]
     fn track_multiple_wraps_link() {
-        let mut tracker = LinkTracker::debug();
+        let mut tracker = LinkTracker::default();
 
         tracker.track(&Span::new("nothing ".to_owned(), MdModifier::default()));
 

--- a/src/worker/sections.rs
+++ b/src/worker/sections.rs
@@ -11,7 +11,7 @@ use std::iter::Peekable;
 use std::rc::Rc;
 
 use mdfrier::ratatui::render_line;
-use mdfrier::{Line, LineKind, MarkdownLink};
+use mdfrier::{Line, LineKind, Mapper, MarkdownLink};
 use ratatui::text::Span;
 
 use super::link_tracker::LinkTracker;
@@ -164,7 +164,8 @@ impl<'a, I: Iterator<Item = Line>> SectionIterator<'a, I> {
             });
         }
 
-        let link_tracker = Rc::new(RefCell::new(LinkTracker::debug()));
+        let hide_urls = Mapper::hide_urls(self.theme);
+        let link_tracker = Rc::new(RefCell::new(LinkTracker::default().hide_urls(hide_urls)));
 
         let rendered_lines: Vec<_> = lines
             .into_iter()
@@ -442,7 +443,7 @@ That's all."#;
             lines[0].1,
             vec![
                 LineExtra::Link("http://example.com/link1".into(), 10, 18, None),
-                LineExtra::Link("http://example.com/link2".into(), 54, 62, None),
+                LineExtra::Link("http://example.com/link2".into(), 30, 38, None),
             ]
         );
         assert_eq!(

--- a/src/worker/sections.rs
+++ b/src/worker/sections.rs
@@ -164,7 +164,7 @@ impl<'a, I: Iterator<Item = Line>> SectionIterator<'a, I> {
             });
         }
 
-        let link_tracker = Rc::new(RefCell::new(LinkTracker::default()));
+        let link_tracker = Rc::new(RefCell::new(LinkTracker::debug()));
 
         let rendered_lines: Vec<_> = lines
             .into_iter()
@@ -348,7 +348,7 @@ mod tests {
             panic!("expected SectionContent::Lines");
         };
         assert_eq!(lines.len(), 1, "one line");
-        assert!(matches!(lines[0].1.as_slice(), [LineExtra::Link(_, _, _)]),);
+        assert!(matches!(lines[0].1.as_slice(), [LineExtra::Link(..)]),);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
             panic!("expected SectionContent::Lines");
         };
         assert_eq!(lines.len(), 1);
-        assert!(matches!(lines[0].1.as_slice(), [LineExtra::Link(_, _, _)]),);
+        assert!(matches!(lines[0].1.as_slice(), [LineExtra::Link(..)]),);
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod tests {
             .1
             .iter()
             .filter_map(|extra| {
-                if let LineExtra::Link(url, _, _) = extra {
+                if let LineExtra::Link(url, ..) = extra {
                     Some(url)
                 } else {
                     None
@@ -407,7 +407,7 @@ mod tests {
             .1
             .iter()
             .filter_map(|extra| {
-                if let LineExtra::Link(url, _, _) = extra {
+                if let LineExtra::Link(url, ..) = extra {
                     Some(url)
                 } else {
                     None
@@ -441,13 +441,18 @@ That's all."#;
         assert_eq!(
             lines[0].1,
             vec![
-                LineExtra::Link("http://example.com/link1".into(), 10, 18),
-                LineExtra::Link("http://example.com/link2".into(), 54, 62),
+                LineExtra::Link("http://example.com/link1".into(), 10, 18, None),
+                LineExtra::Link("http://example.com/link2".into(), 54, 62, None),
             ]
         );
         assert_eq!(
             lines[1].1,
-            vec![LineExtra::Link("http://example.com/link3".into(), 45, 55),]
+            vec![LineExtra::Link(
+                "http://example.com/link3".into(),
+                45,
+                55,
+                None
+            ),]
         );
     }
 }


### PR DESCRIPTION
Do not wrap URLs if possible. Instead, break the line immediately.

In general, it seems like LinkTracker *should* work around this, because with this, a URL could still exceed the viewport width and get broken.

Fixes #126 