### PR TITLE
Header fix jump

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -219,21 +219,27 @@ impl Document {
         None
     }
 
-    // Find first should be slightly more efficient.
+    /// Find first cursor in visible lines
+    ///
+    /// Find the first cursor in visible lines, or the first after, or the earliest before, in
+    /// that order.
     pub fn find_first_cursor<'b, Iter: Iterator<Item = &'b Section>>(
-        iter: Iter,
+        sections: Iter,
         target: FindTarget,
         scroll: u16,
     ) -> Option<CursorPointer> {
-        let locate = move |section: &Section| -> Option<CursorPointer> {
+        let locate = move |section: &Section| -> Option<(u16, CursorPointer)> {
             if let SectionContent::Lines(lines) = &section.content {
                 let mut flat_index = 0;
-                for (_, extras) in lines {
+                for (line_y, (_, extras)) in lines.iter().enumerate() {
                     if let Some(i) = extras.iter().position(|extra| target.matches(extra)) {
-                        return Some(CursorPointer {
-                            id: section.id,
-                            index: flat_index + i,
-                        });
+                        return Some((
+                            line_y as u16,
+                            CursorPointer {
+                                id: section.id,
+                                index: flat_index + i,
+                            },
+                        ));
                     }
                     flat_index += extras.len();
                 }
@@ -241,22 +247,21 @@ impl Document {
             None
         };
 
-        let mut first = None;
-        let mut offset_acc = 0;
-        for section in iter {
-            offset_acc += section.height;
-            if offset_acc < scroll + 1 {
-                if first.is_none() {
-                    first = locate(section);
-                }
-                continue;
+        let mut last = None;
+        let mut y = 0;
+        for section in sections {
+            let next = locate(section);
+            if let Some((line_y, _)) = &next
+                && y + line_y >= scroll
+            {
+                return next.map(|f| f.1);
             }
-            match locate(section) {
-                None => {}
-                x => return x,
+            if next.is_some() {
+                last = next.map(|f| f.1);
             }
+            y += section.height;
         }
-        first
+        last
     }
 
     // Find nth (nonzero) next cursor.

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -62,8 +62,7 @@ pub fn poll(had_events: bool, model: &mut Model) -> Result<PollResult, Error> {
 }
 
 fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> {
-    // TODO: adjust padding or whatever properly
-    let page_scroll_count = model.inner_height() as i32 - 2;
+    let page_scroll_count = model.inner_height() as i32 - 1;
 
     match key.code {
         // Search-input mode captures any `KeyCode::Char(_)`.

--- a/src/model.rs
+++ b/src/model.rs
@@ -148,6 +148,7 @@ impl Model {
         self.config
             .padding
             .calculate_height(self.screen_size.height)
+            .saturating_sub(1) // Account for the status line at the bottom.
     }
 
     pub fn block_padding(&self, area: Rect) -> Padding {
@@ -280,14 +281,14 @@ impl Model {
 
         self.scroll = min(
             new_scroll,
-            self.total_lines().saturating_sub(self.inner_height()) + 1,
+            self.total_lines().saturating_sub(self.inner_height()),
         );
     }
 
     pub fn visible_lines(&self) -> (i16, i16) {
         let start_y = self.scroll as i16;
         // We don't render the last line, so sub one extra:
-        let end_y = start_y + self.inner_height() as i16 - 2;
+        let end_y = start_y + (self.inner_height() as i16).saturating_sub(1);
         (start_y, end_y)
     }
 
@@ -326,12 +327,8 @@ impl Model {
 
             self.cursor = Cursor::None;
             self.scroll = y as u16;
-            if remaining_document_height < self.inner_height() - 1 {
-                log::debug!(
-                    "remaining: {remaining_document_height} / {}",
-                    self.inner_height()
-                );
-                self.scroll -= self.inner_height() - 1 - remaining_document_height;
+            if remaining_document_height < self.inner_height() {
+                self.scroll -= self.inner_height() - remaining_document_height;
             }
             return Ok(());
         }
@@ -884,7 +881,7 @@ mod tests {
         let mut y: i16 = 0 - (model.scroll as i16);
         for source in model.document.iter() {
             y += source.height as i16;
-            if y >= model.inner_height() as i16 - 1 {
+            if y >= model.inner_height() as i16 {
                 last_rendered = Some(source);
                 break;
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -287,7 +287,6 @@ impl Model {
 
     pub fn visible_lines(&self) -> (i16, i16) {
         let start_y = self.scroll as i16;
-        // We don't render the last line, so sub one extra:
         let end_y = start_y + (self.inner_height() as i16).saturating_sub(1);
         (start_y, end_y)
     }
@@ -606,6 +605,7 @@ mod tests {
         model::{InputQueue, Model},
     };
 
+    /// Test model, 80x20 screen size.
     fn test_model() -> Model {
         let (cmd_tx, _) = mpsc::channel::<Cmd>();
         let (_, event_rx) = mpsc::channel::<Event>();
@@ -631,7 +631,7 @@ mod tests {
                 model
                     .cursor
                     .pointer()
-                    .expect("model.cursor.pointer() should be Some(CursorPointer{ .. })"),
+                    .expect("model.cursor.pointer() should be Some"),
             )
             .expect("find_extra_by_cursor(...).unwrap()")
         else {

--- a/src/model.rs
+++ b/src/model.rs
@@ -294,30 +294,45 @@ impl Model {
     pub fn open_link(&mut self, url: String) -> Result<(), Error> {
         if let Some(header_reference) = url.strip_prefix("#") {
             let pointer = {
-                let mut pointer = None;
-                for Section { id, content, .. } in self.document.iter() {
+                let mut target = None;
+                for Section {
+                    id,
+                    content,
+                    height,
+                } in self.document.iter()
+                {
                     if let SectionContent::Header(text, _, _) = content {
                         // Is this `#kebab-case` the only scheme? Probably not.
                         if text.to_lowercase().replace(' ', "-") == header_reference {
-                            pointer = Some(CursorPointer { id: *id, index: 0 });
+                            let Some(y) = self.document.get_y(&CursorPointer { id: *id, index: 0 })
+                            else {
+                                return Err(Error::Generic(format!(
+                                    "Header position not found: {}",
+                                    url
+                                )));
+                            };
+                            target = Some((y, 0));
                         }
                     }
+                    if let Some((_, target_height)) = &mut target {
+                        *target_height += height;
+                    }
                 }
-                pointer
+                target
             };
-            let Some(pointer) = pointer else {
+            let Some((y, remaining_document_height)) = pointer else {
                 return Err(Error::Generic(format!("Header link not found: {}", url)));
             };
-            // This will put the id in the pointer, and `#something-something` in the status.
-            let Some(y) = self.document.get_y(&pointer) else {
-                return Err(Error::Generic(format!(
-                    "Header position not found: {}",
-                    url
-                )));
-            };
 
-            self.cursor = Cursor::Search(url, Some(pointer));
+            self.cursor = Cursor::None;
             self.scroll = y as u16;
+            if remaining_document_height < self.inner_height() - 1 {
+                log::debug!(
+                    "remaining: {remaining_document_height} / {}",
+                    self.inner_height()
+                );
+                self.scroll -= self.inner_height() - 1 - remaining_document_height;
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
If remaining document height is smaller than viewport, substract
difference. Fixes jumping beyond end of document.