### PR TITLE
don't hide_urls on BareLink, include in link tracking

### DIFF
--- a/mdfrier/src/lib.rs
+++ b/mdfrier/src/lib.rs
@@ -466,11 +466,11 @@ Quote break.
             spans,
             vec![
                 Span::from("See "),
-                Span::with("(", Modifier::LinkURLWrapper),
+                Span::with("(", Modifier::LinkURLWrapper | Modifier::BareLink),
                 Span::with("https://", Modifier::LinkURL | Modifier::BareLink),
                 Span::with("example.com/", Modifier::LinkURL | Modifier::BareLink,),
                 Span::with("path", Modifier::LinkURL | Modifier::BareLink,),
-                Span::with(")", Modifier::LinkURLWrapper),
+                Span::with(")", Modifier::LinkURLWrapper | Modifier::BareLink),
                 Span::with(" ok?", Modifier::empty()),
             ]
         );

--- a/mdfrier/src/markdown.rs
+++ b/mdfrier/src/markdown.rs
@@ -398,7 +398,9 @@ bitflags! {
 impl Modifier {
     // Returns true if LinkURL but not Image.
     pub fn is_link_url(&self) -> bool {
-        self.contains(Modifier::LinkURL) && !self.contains(Modifier::Image)
+        self.contains(Modifier::LinkURL)
+            && !self.contains(Modifier::BareLink)
+            && !self.contains(Modifier::Image)
     }
     /// Returns true if contains `modifier` but not [`Modifier::Image`].
     pub fn is_link_modifier(&self, modifier: Modifier) -> bool {
@@ -810,10 +812,10 @@ fn detect_bare_urls(mdspans: Vec<Span>) -> Vec<Span> {
 
             // Opening wrapper - only keep NewLine if this is the first span emitted
             let wrapper_mods = if first_emitted {
-                base_modifiers | Modifier::LinkURLWrapper
+                base_modifiers | Modifier::BareLink | Modifier::LinkURLWrapper
             } else {
                 first_emitted = true;
-                span.modifiers | Modifier::LinkURLWrapper
+                span.modifiers | Modifier::BareLink | Modifier::LinkURLWrapper
             };
             result.push(Span::new("(".to_owned(), wrapper_mods));
 
@@ -821,13 +823,13 @@ fn detect_bare_urls(mdspans: Vec<Span>) -> Vec<Span> {
             let url = mat.as_str().to_owned();
             result.push(Span::new(
                 url,
-                base_modifiers | Modifier::LinkURL | Modifier::BareLink,
+                base_modifiers | Modifier::BareLink | Modifier::LinkURL,
             ));
 
             // Closing wrapper
             result.push(Span::new(
                 ")".to_owned(),
-                base_modifiers | Modifier::LinkURLWrapper,
+                base_modifiers | Modifier::BareLink | Modifier::LinkURLWrapper,
             ));
 
             last_end = mat.end();
@@ -971,15 +973,35 @@ mod tests {
         let result = detect_bare_urls(spans);
         assert_eq!(result.len(), 5);
         assert_eq!(result[0].content, "Check ");
-        assert!(!result[0].modifiers.contains(Modifier::LinkURL));
+        assert!(
+            !result[0]
+                .modifiers
+                .contains(Modifier::BareLink | Modifier::LinkURL)
+        );
         assert_eq!(result[1].content, "(");
-        assert!(result[1].modifiers.contains(Modifier::LinkURLWrapper));
+        assert!(
+            result[1]
+                .modifiers
+                .contains(Modifier::BareLink | Modifier::LinkURLWrapper)
+        );
         assert_eq!(result[2].content, "https://example.com");
-        assert!(result[2].modifiers.contains(Modifier::LinkURL));
+        assert!(
+            result[2]
+                .modifiers
+                .contains(Modifier::BareLink | Modifier::LinkURL)
+        );
         assert_eq!(result[3].content, ")");
-        assert!(result[3].modifiers.contains(Modifier::LinkURLWrapper));
+        assert!(
+            result[3]
+                .modifiers
+                .contains(Modifier::BareLink | Modifier::LinkURLWrapper)
+        );
         assert_eq!(result[4].content, " for more.");
-        assert!(!result[4].modifiers.contains(Modifier::LinkURL));
+        assert!(
+            !result[4]
+                .modifiers
+                .contains(Modifier::BareLink | Modifier::LinkURL)
+        );
     }
 
     #[test]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -28,11 +28,7 @@ pub fn init_logger(log_to_stderr: bool) -> Result<(), FlexiLoggerError> {
 #[cfg(test)]
 pub fn init_test_logger() {
     #[expect(clippy::let_underscore_untyped, clippy::unwrap_used)]
-    let _ = Logger::try_with_env()
-        .unwrap()
-        .log_to_stderr()
-        .start()
-        .inspect_err(|err| eprintln!("test logger setup failed: {err}"));
+    let _ = Logger::try_with_env().unwrap().log_to_stderr().start();
 }
 
 #[cfg(not(windows))]

--- a/src/worker/link_tracker.rs
+++ b/src/worker/link_tracker.rs
@@ -7,7 +7,7 @@ use unicode_width::UnicodeWidthStr as _;
 
 use crate::document::LineExtra;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 /// Iterator over [`mdfrier::Span`]s and extract links as [`LineExtra::Link`]`(url, start, end)`,
 /// where "start" and "end" are the respective positions in the [`mdfrier::Line`].
 pub struct LinkTracker {
@@ -105,6 +105,15 @@ impl LinkTracker {
             };
             // Exit URL, can build the LinkExtra::Link now.
             self.exit(start, end, lines, url.as_str());
+
+        // BareLink:
+        } else if self.link_builder == LinkExtraLinkBuilder::None
+            && node
+                .modifiers
+                .is_link_modifier(MdModifier::BareLink | MdModifier::LinkURL)
+        {
+            // BareLink, enter and exit immediately.
+            self.exit(self.offset, self.offset + span_width, 0, &node.content);
         }
         if self.hide_urls {
             if !node.modifiers.is_link_url() {
@@ -328,6 +337,24 @@ mod tests {
         assert_eq!(
             extras[0],
             LineExtra::Link(SourceContent::from("url-1/url-2"), 9, 5, Some(2)),
+        );
+    }
+
+    #[test]
+    fn track_bare_link() {
+        let mut tracker = LinkTracker::default();
+
+        tracker.track(&Span::new(
+            "http://bare".to_owned(),
+            MdModifier::Link | MdModifier::LinkURL | MdModifier::BareLink,
+        ));
+        let extras = tracker.extras();
+        // ```
+        // http://bare
+        // ```
+        assert_eq!(
+            extras[0],
+            LineExtra::Link(SourceContent::from("http://bare"), 0, 11, None),
         );
     }
 }


### PR DESCRIPTION
Obviously don't hide, and include BareLink in tracking.

Fixes bare URLs not rendering at all, and then also being excluded from link navigation.