### PR TITLE
produce lines with the links in headers

### DIFF
--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -186,7 +186,7 @@ impl<'a, M: Mapper> LineIterator<'a, M> {
         self.prev_was_blank = is_blank_line;
         self.prev_in_list = in_list;
 
-        let lines = section_to_lines(self.width, &section, self.mapper);
+        let lines = section_to_lines(self.width, section, self.mapper);
         self.pending_lines.extend(lines);
 
         true
@@ -215,10 +215,10 @@ impl<M: Mapper> Iterator for LineIterator<'_, M> {
 
 /// Convert a markdown section to output lines.
 /// Applies mapper decorators before wrapping so widths are correct.
-fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> Vec<Line> {
+fn section_to_lines<M: Mapper>(width: u16, section: MdSection, mapper: &M) -> Vec<Line> {
     let nesting = convert_nesting(&section.nesting, section.is_list_continuation);
 
-    match &section.content {
+    match section.content {
         MdContent::Paragraph(p) if p.is_empty() => {
             vec![Line {
                 spans: Vec::new(),
@@ -228,7 +228,7 @@ fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> V
         }
         MdContent::Paragraph(p) => {
             // Apply decorators first, then wrap
-            let decorated_spans = apply_decorators(p.spans.clone(), mapper);
+            let decorated_spans = apply_decorators(p.spans, mapper);
             let prefix_width: usize = nesting
                 .iter()
                 .map(|c| match c {
@@ -240,8 +240,8 @@ fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> V
                 wrap_md_spans(width, decorated_spans, prefix_width, mapper.hide_urls());
             wrapped_to_lines(wrapped_lines, nesting, mapper)
         }
-        MdContent::Header { tier, text } => {
-            if mapper.has_text_size_protocol() {
+        MdContent::Header { tier, text, links } => {
+            let mut lines = if mapper.has_text_size_protocol() {
                 // We only pre-wrap headers for text-size-protocol. When rendering image, the
                 // wrapping is taken care of the image renderer, as the font size is not known
                 // here.
@@ -260,17 +260,31 @@ fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> V
                     .into_iter()
                     .map(|line| Line {
                         spans: line.spans,
-                        kind: LineKind::Header(*tier),
-                        urls: Vec::new(), // TODO: headers should be able to have links
+                        kind: LineKind::Header(tier),
+                        urls: Vec::new(),
                     })
                     .collect()
             } else {
                 vec![Line {
                     spans: vec![Span::from(text.clone())],
-                    kind: LineKind::Header(*tier),
-                    urls: Vec::new(), // TODO: Same
+                    kind: LineKind::Header(tier),
+                    urls: Vec::new(),
                 }]
+            };
+
+            if !links.is_empty()
+                && let Some(joined) = links.into_iter().reduce(|mut acc, next| {
+                    acc.push(Span::new(String::from(" "), Modifier::default()));
+                    acc.extend(next);
+                    acc
+                })
+            {
+                let decorated_spans = apply_decorators(joined, mapper);
+                let wrapped_lines = wrap_md_spans(width, decorated_spans, 0, mapper.hide_urls());
+                lines.extend(wrapped_to_lines(wrapped_lines, Vec::new(), mapper));
             }
+
+            lines
         }
         MdContent::CodeBlock { language, code } => {
             code_block_to_lines(width, language, code, nesting, mapper)
@@ -295,7 +309,7 @@ fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> V
             header,
             rows,
             alignments,
-        } => table_to_lines(width, header, rows, alignments, nesting, mapper),
+        } => table_to_lines(width, &header, &rows, &alignments, nesting, mapper),
         MdContent::Html { html } => html
             .split("\n")
             .map(|linestr| Line {
@@ -307,15 +321,15 @@ fn section_to_lines<M: Mapper>(width: u16, section: &MdSection, mapper: &M) -> V
         MdContent::LinkReferenceDefinition { reference, url } => {
             let spans = vec![
                 Span::new("[".to_owned(), Modifier::LinkDescriptionWrapper),
-                Span::new(reference.to_owned(), Modifier::LinkDescription),
+                Span::new(reference.clone(), Modifier::LinkDescription),
                 Span::new("]".to_owned(), Modifier::LinkDescriptionWrapper),
                 Span::new(": ".to_owned(), Modifier::LinkURLWrapper),
-                Span::new(url.to_owned(), Modifier::BareLink | Modifier::LinkURL),
+                Span::new(url.clone(), Modifier::BareLink | Modifier::LinkURL),
             ];
             let start =
                 (spans[0].width() + spans[1].width() + spans[2].width() + spans[3].width()) as u16;
             let end = start + spans[4].width() as u16;
-            let urls = vec![TrackedUrl::link(url.to_owned(), start, end, 0)];
+            let urls = vec![TrackedUrl::link(url.clone(), start, end, 0)];
             vec![Line {
                 spans,
                 kind: LineKind::LinkReferenceDefinitions,
@@ -568,8 +582,8 @@ fn convert_nesting(md_nesting: &[MdContainer], is_list_continuation: bool) -> Ve
 /// Convert a code block to output lines.
 fn code_block_to_lines<M: Mapper>(
     width: u16,
-    language: &str,
-    code: &str,
+    language: String,
+    code: String,
     nesting: Vec<MdLineContainer>,
     mapper: &M,
 ) -> Vec<Line> {
@@ -608,7 +622,7 @@ fn code_block_to_lines<M: Mapper>(
                 result.push(Line {
                     spans,
                     kind: LineKind::CodeBlock {
-                        language: language.to_owned(),
+                        language: language.clone(),
                     },
                     urls: Vec::new(),
                 });
@@ -625,7 +639,7 @@ fn code_block_to_lines<M: Mapper>(
             result.push(Line {
                 spans,
                 kind: LineKind::CodeBlock {
-                    language: language.to_owned(),
+                    language: language.clone(),
                 },
                 urls: Vec::new(),
             });

--- a/mdfrier/src/markdown.rs
+++ b/mdfrier/src/markdown.rs
@@ -130,9 +130,39 @@ impl<'a> MdIterator<'a> {
             "atx_heading" => {
                 let mut tier = 0;
                 let mut text = "";
+                let mut links: Vec<Vec<Span>> = Vec::new();
                 for child in node.children(&mut node.walk()) {
                     match child.kind() {
-                        "inline" => text = &self.source[child.byte_range()],
+                        "inline" => {
+                            text = &self.source[child.byte_range()];
+                            if let Some(tree) = self.inline_parser.parse(text, None)
+                                && let Some(MdContent::Paragraph(p)) =
+                                    // TODO: should make a specific parser only for links in
+                                    // headers here.
+                                    MdParagraph::from_inline(tree.root_node(), text, 0)
+                            {
+                                let mut link: Vec<Span> = Vec::new();
+                                for span in p.spans {
+                                    if span.modifiers.contains(Modifier::Link) {
+                                        let is_end =
+                                            (span.modifiers.contains(Modifier::LinkURLWrapper)
+                                                && link
+                                                    .last()
+                                                    .map(|last| {
+                                                        last.modifiers.contains(Modifier::LinkURL)
+                                                    })
+                                                    .unwrap_or(false))
+                                                || (span.modifiers.contains(Modifier::LinkURL)
+                                                    && span.content.starts_with("[")
+                                                    && span.content.ends_with("]"));
+                                        link.push(span);
+                                        if is_end {
+                                            links.push(std::mem::take(&mut link));
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         "atx_h1_marker" => tier = 1,
                         "atx_h2_marker" => tier = 2,
                         "atx_h3_marker" => tier = 3,
@@ -147,6 +177,7 @@ impl<'a> MdIterator<'a> {
                 Some(MdContent::Header {
                     tier,
                     text: text.to_owned(),
+                    links,
                 })
             }
             "block_continuation" => {
@@ -565,6 +596,7 @@ pub(crate) enum MdContent {
     Header {
         tier: u8,
         text: String,
+        links: Vec<Vec<Span>>,
     },
     CodeBlock {
         language: String,
@@ -1210,6 +1242,61 @@ mod tests {
         assert_eq!(
             spans[9],
             Span::with(")", Modifier::Link | Modifier::LinkURLWrapper)
+        );
+    }
+
+    #[test]
+    fn header_with_links() {
+        let mut parser = make_parser();
+        let mut inline_parser = make_inline_parser();
+        let source = "# Header [with link!](https://crates.io/crates/mdfried), [second][ref], [third](http://third), and [another][ref].\n";
+        let tree = parser.parse(source, None).unwrap();
+        let sections: Vec<_> = MdIterator::new(tree, &mut inline_parser, source).collect();
+        assert_eq!(sections.len(), 1);
+        fn link(desc: &str, url: &str) -> Vec<Span> {
+            vec![
+                Span::new(
+                    "[".to_owned(),
+                    Modifier::Link | Modifier::LinkDescriptionWrapper,
+                ),
+                Span::new(desc.to_owned(), Modifier::Link | Modifier::LinkDescription),
+                Span::new(
+                    "]".to_owned(),
+                    Modifier::Link | Modifier::LinkDescriptionWrapper,
+                ),
+                Span::new("(".to_owned(), Modifier::Link | Modifier::LinkURLWrapper),
+                Span::new(url.to_owned(), Modifier::Link | Modifier::LinkURL),
+                Span::new(")".to_owned(), Modifier::Link | Modifier::LinkURLWrapper),
+            ]
+        }
+        fn link_ref(desc: &str, refe: &str) -> Vec<Span> {
+            vec![
+                Span::new(
+                    "[".to_owned(),
+                    Modifier::Link | Modifier::LinkDescriptionWrapper,
+                ),
+                Span::new(desc.to_owned(), Modifier::Link | Modifier::LinkDescription),
+                Span::new(
+                    "]".to_owned(),
+                    Modifier::Link | Modifier::LinkDescriptionWrapper,
+                ),
+                Span::new(format!("[{refe}]"), Modifier::Link | Modifier::LinkURL),
+            ]
+        }
+        assert_eq!(
+            sections[0].content,
+            MdContent::Header {
+                tier: 1,
+                text: String::from(
+                    "Header [with link!](https://crates.io/crates/mdfried), [second][ref], [third](http://third), and [another][ref]."
+                ),
+                links: vec![
+                    link("with link!", "https://crates.io/crates/mdfried"),
+                    link_ref("second", "ref"),
+                    link("third", "http://third"),
+                    link_ref("another", "ref"),
+                ],
+            },
         );
     }
 }


### PR DESCRIPTION
`# Header [with](http://link)`

Simply keeps producing the raw header, but also each link as a line below it.

Fixes #118 