### PR TITLE
`:help` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,26 +84,10 @@ See `--help` for all options.
 
 ### Key bindings
 
-Key | Description
-----|------------
-`q` or `Ctrl-c` | Quit and leave contents on terminal
-`r` | Reload the file (unless piped stdin)
-`j` | Scroll down one line
-`k` | Scroll up one line
-`d` or `Ctrl-d` | Scroll down half page
-`u` or `Ctrl-u` | Scroll up half page
-`f` or `PageDown` or `Space` | Scroll down a page
-`b` or `PageUp` | Scroll up a page
-`g` | Go to start of file
-`G` | Go to end of file
-`<number>G` or `<number>g` | Go to the string #\<number>
-`/` | Search text
-`n` | Jump to next match or link
-`N` | Jump to previous match or link
-`Enter` | Open selected link with `xdg-open` (linux) or `open` (macos)
-`Esc` | Leave search or link modes
+The keybindings should follow the basics of general CLI pagers. Vi-style keybindings are 
+prioritized, but "normal" keys should be usable as well.
 
-Entering a number before motion applies the motion that many times.
+Type `:help` in the program to see the exact list, or see [assets/help.md](assets/help.md).
 
 Mouse scroll only works if enabled in settings as `enable_mouse_capture = true`, but then you can't
 select text.

--- a/assets/help.md
+++ b/assets/help.md
@@ -1,0 +1,34 @@
+# Help
+
+**Press `Esc` or type `:back` to exit this help document.**
+
+### Key bindings
+
+Key | Alt Key(s) | Description
+----|------------|------------
+`q` | `Ctrl-c`   | Quit and leave contents on terminal
+`r` |            | Reload the file (unless piped stdin)
+`j` | `↑`        | Scroll down one line
+`k` | `↓`        | Scroll up one line
+`d` | `Ctrl-d`   | Scroll down half page
+`u` | `Ctrl-u`   | Scroll up half page
+`f` | `PageDown`, `Space` | Scroll down a page
+`b` | `PageUp`   | Scroll up a page
+`g` |            | Go to start of file
+`G` |            | Go to end of file
+`<number>G` | `<number>g` | Jump to line #\<number>
+`/` |            | Search text
+`n` |            | Jump to next match or link
+`N` |            | Jump to previous match or link
+`Enter` |        | Open or follow selected link
+`Esc` |          | Leave search or link modes
+
+Entering a number before motion applies the motion that many times.
+
+### Commands
+
+Command | Description
+--------|------------
+`:help` | Opens this help markdown document
+`:back` | Go back one entry in history
+

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -67,7 +67,6 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
     match key.code {
         // Search-input mode captures any `KeyCode::Char(_)`.
         KeyCode::Char(c) if matches!(model.input_queue, InputQueue::Search(_)) => {
-            // We could also match over (key.code, model.input_queue).
             let InputQueue::Search(needle) = &mut model.input_queue else {
                 panic!("invariant InputQueue::Search");
             };
@@ -75,6 +74,13 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
             let clone = needle.clone();
             model.add_searches(Some(&clone));
             model.cursor = Cursor::Search(clone, None);
+        }
+        // Command-input mode captures any `KeyCode::Char(_)`.
+        KeyCode::Char(c) if matches!(model.input_queue, InputQueue::Command(_)) => {
+            let InputQueue::Command(command) = &mut model.input_queue else {
+                panic!("invariant InputQueue::Command");
+            };
+            command.push(c);
         }
         // Digits start a movement-count.
         KeyCode::Char(x)
@@ -91,11 +97,11 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
                         .saturating_mul(NonZero::new(10).expect("10 != 0"))
                         .saturating_add(x);
                 }
-                InputQueue::Search(_) => {
-                    panic!("invariant is_ascii_digit while in search");
-                }
                 InputQueue::CursorPositioningCommands => {
                     model.input_queue = InputQueue::None;
+                }
+                InputQueue::Search(_) | InputQueue::Command(_) => {
+                    panic!("invariant is_ascii_digit while in invalid InputQueue mode");
                 }
             }
         }
@@ -185,11 +191,26 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
             model.input_queue = InputQueue::Search(String::new());
             model.cursor = Cursor::Search(String::new(), None);
         }
+        KeyCode::Char(':') => {
+            model.input_queue = InputQueue::Command(String::new());
+        }
         KeyCode::Enter if matches!(model.input_queue, InputQueue::Search(_)) => {
             // Exit search...
             model.input_queue = InputQueue::None;
             // ...and jump to first match.
             model.cursor_next(1);
+        }
+        KeyCode::Enter if matches!(model.input_queue, InputQueue::Command(_)) => {
+            let InputQueue::Command(command) =
+                std::mem::replace(&mut model.input_queue, InputQueue::None)
+            else {
+                panic!("invariant InputQueue::Command");
+            };
+
+            if let Err(err) = model.user_command_str(command) {
+                // Once we display error messages, let this return and be catched higher up.
+                log::error!("{err}");
+            }
         }
         KeyCode::Enter => {
             // Open links with xdg-open
@@ -220,6 +241,9 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
                 }
             }
         }
+        KeyCode::Esc if model.is_help_screen()? => {
+            model.history_pop()?;
+        }
         KeyCode::Esc => match model.input_queue {
             InputQueue::None => {
                 // This is not vim-canon: Esc is the equivalent of `:noh`. This works because we
@@ -231,16 +255,14 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
                     _ => {}
                 }
             }
-            InputQueue::MovementCount(_) => {
-                // Abort movement-count input.
-                model.input_queue = InputQueue::None;
-            }
             InputQueue::Search(_) => {
                 // Abort search input.
                 model.input_queue = InputQueue::None;
                 model.cursor = Cursor::None;
             }
-            InputQueue::CursorPositioningCommands => {
+            InputQueue::MovementCount(_)
+            | InputQueue::CursorPositioningCommands
+            | InputQueue::Command(_) => {
                 model.input_queue = InputQueue::None;
             }
         },
@@ -261,6 +283,13 @@ fn match_keycode(key: KeyEvent, model: &mut Model) -> Result<PollResult, Error> 
                     needle.pop();
                     let clone = needle.clone();
                     model.add_searches(Some(&clone));
+                }
+            }
+            InputQueue::Command(command) => {
+                if command.is_empty() {
+                    model.input_queue = InputQueue::None;
+                } else {
+                    command.pop();
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,9 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
         None
     };
 
-    run(&mut terminal, model)?;
+    if let Err(err) = run(&mut terminal, model) {
+        eprintln!("Runtime error: {err}");
+    };
     drop(debouncer);
 
     // Cursor might be in wird places, prompt or whatever should always show at the bottom now.
@@ -326,7 +328,7 @@ pub enum Event {
     HeaderLoaded(DocumentId, SectionID, Vec<(String, u8, Protocol)>),
     FileChanged,
     Scroll(i16),
-    NewSource(String),
+    NewSourceContent(String),
     ReferenceDefinition { id: String, url: String },
 }
 
@@ -367,7 +369,7 @@ impl Display for Event {
             }
             Event::FileChanged => write!(f, "Event::FileChanged"),
             Event::Scroll(s) => write!(f, "Event::Scroll({s})"),
-            Event::NewSource(_) => write!(f, "Event::NewSource"),
+            Event::NewSourceContent(_) => write!(f, "Event::NewSource"),
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,6 +15,7 @@ use ratatui::{
     widgets::Padding,
 };
 use regex::RegexBuilder;
+use url::Url;
 
 use crate::{
     Cmd,
@@ -22,7 +23,7 @@ use crate::{
     cursor::{Cursor, CursorPointer},
     document::{Document, FindMode, FindTarget, LineExtra, Section, SectionContent},
     error::Error,
-    sources::{DocumentSource, extend_url, github_usercontent_url},
+    sources::{DocumentHistoryEntry, DocumentSource, extend_url, github_usercontent_url},
     worker::ImageCache,
 };
 use crate::{Event, sources::SharedDocumentSource};
@@ -35,6 +36,7 @@ pub struct Model {
     document: Document,
     document_id: DocumentId,
     document_source: SharedDocumentSource,
+    document_history: Vec<DocumentHistoryEntry>,
     config: Config,
     cmd_tx: Sender<Cmd>,
     event_rx: Receiver<Event>,
@@ -48,6 +50,7 @@ pub enum InputQueue {
     MovementCount(NonZero<u16>),
     Search(String),
     CursorPositioningCommands,
+    Command(String),
 }
 impl InputQueue {
     // Convenience for model "cursor_find" method. Consumes the input, resets self to
@@ -86,16 +89,17 @@ impl Model {
         config: Config,
     ) -> Model {
         Model {
-            document_source,
             screen_size,
             config,
             scroll: 0,
             input_queue: InputQueue::None,
             cursor: Cursor::default(),
             document: Document::default(),
+            document_id: DocumentId::default(),
+            document_source,
+            document_history: Vec::new(),
             cmd_tx,
             event_rx,
-            document_id: DocumentId::default(),
         }
     }
 
@@ -115,6 +119,37 @@ impl Model {
 
     pub fn open(&self, text: String) -> Result<(), Error> {
         self.parse(self.document_id.open(), text, None)
+    }
+
+    fn open_new_source(&mut self, source: DocumentSource, text: String) -> Result<(), Error> {
+        self.document_history.push(DocumentHistoryEntry {
+            source: self.document_source.read()?,
+            document: std::mem::take(&mut self.document), // resets self.document to default
+            scroll: self.scroll,
+        });
+        self.document_source.write(source)?;
+        self.cursor = Cursor::None;
+        self.scroll = 0;
+        self.input_queue = InputQueue::None;
+        self.open(text)
+    }
+
+    pub fn history_pop(&mut self) -> Result<(), Error> {
+        let DocumentHistoryEntry {
+            source,
+            document,
+            scroll,
+        } = self
+            .document_history
+            .pop()
+            .ok_or(Error::Generic("No history to go back".to_owned()))?;
+        self.document_source.write(source)?;
+        self.document = document;
+        self.cursor = Cursor::None;
+        self.scroll = scroll;
+        self.input_queue = InputQueue::None;
+
+        Ok(())
     }
 
     pub fn reparse(&mut self, text: String) -> Result<(), Error> {
@@ -258,19 +293,8 @@ impl Model {
                 Event::Scroll(delta) => {
                     self.scroll = self.scroll.saturating_add_signed(delta);
                 }
-                Event::NewSource(text) => {
-                    // This looks like we should have a method to "clear everything".
-                    self.document_id = self.document_id.next();
-                    self.document = Document::default();
-                    self.cursor = Cursor::None;
-                    self.scroll = 0;
-                    self.input_queue = InputQueue::None;
-                    // We should also think about having some kind of history stack, with:
-                    // * file name
-                    // * scroll
-                    // * cursor
-                    // * ???
-                    self.open(text)?;
+                Event::NewSourceContent(text) => {
+                    self.open_new_source(self.document_source.read()?, text)?;
                 }
             }
         }
@@ -356,38 +380,41 @@ impl Model {
             return Ok(());
         }
 
-        match self.document_source.read() {
-            Ok(DocumentSource::File { .. }) | Ok(DocumentSource::Stdin) | Err(_) => {
+        match self.document_source.read()? {
+            source @ DocumentSource::File { .. }
+            | source @ DocumentSource::Stdin
+            | source @ DocumentSource::BuiltInHelp => {
                 let url_as_path = Path::new(&link_url);
                 if url_as_path.extension() == Some(std::ffi::OsStr::new("md"))
                     && fs::exists(url_as_path).unwrap_or_default()
                     && let Ok(text) = fs::read_to_string(url_as_path)
                 {
-                    // This looks like we should have a method to "clear everything".
-                    self.document_id = self.document_id.next();
-                    self.document = Document::default();
-                    self.cursor = Cursor::None;
-                    self.scroll = 0;
-                    self.input_queue = InputQueue::None;
-                    // We should also think about having some kind of history stack, with:
-                    // * file name
-                    // * scroll
-                    // * cursor
-                    // * ???
-                    return self.open(text);
+                    self.open_new_source(source, text)?;
                 }
 
                 if let Err(err) = open::that(&link_url) {
                     log::error!("{err}");
                 }
             }
-            Ok(DocumentSource::Github { repo, branch }) => {
-                let url = github_usercontent_url(&repo, &branch, &link_url)?;
-                self.cmd_tx.send(Cmd::OpenUrl(url))?;
+            DocumentSource::Github { repo, branch } => {
+                if Url::parse(&link_url).is_ok() {
+                    if let Err(err) = open::that(&link_url) {
+                        log::error!("{err}");
+                    }
+                } else {
+                    let url = github_usercontent_url(&repo, &branch, &link_url)?;
+                    self.cmd_tx.send(Cmd::OpenUrl(url))?;
+                }
             }
-            Ok(DocumentSource::HyperText { url }) => {
-                let url = extend_url(url, &link_url)?;
-                self.cmd_tx.send(Cmd::OpenUrl(url))?;
+            DocumentSource::HyperText { url } => {
+                if Url::parse(&link_url).is_ok() {
+                    if let Err(err) = open::that(&link_url) {
+                        log::error!("{err}");
+                    }
+                } else {
+                    let url = extend_url(url, &link_url)?;
+                    self.cmd_tx.send(Cmd::OpenUrl(url))?;
+                }
             }
         }
         Ok(())
@@ -569,6 +596,22 @@ impl Model {
             log::error!("jump_to_pointer without cursor / pointer");
         }
     }
+
+    /// User has typed `:some_command<Enter>`.
+    pub fn user_command_str(&mut self, command: String) -> Result<(), Error> {
+        match command.as_str() {
+            "help" => {
+                const HELP_MD: &str = include_str!("../assets/help.md");
+                self.open_new_source(DocumentSource::BuiltInHelp, String::from(HELP_MD))
+            }
+            "back" => self.history_pop(),
+            _ => Err(Error::Generic("unknown command: {command}".to_owned())),
+        }
+    }
+
+    pub fn is_help_screen(&self) -> Result<bool, Error> {
+        Ok(self.document_source.read()? == DocumentSource::BuiltInHelp)
+    }
 }
 
 #[derive(Default, Debug, PartialEq, Clone, Copy)]
@@ -598,13 +641,6 @@ impl DocumentId {
 
     fn is_first_load(&self) -> bool {
         self.reload_id == 0
-    }
-
-    fn next(&self) -> DocumentId {
-        DocumentId {
-            id: self.id + 1,
-            reload_id: 0,
-        }
     }
 }
 
@@ -654,7 +690,6 @@ mod tests {
         let (cmd_tx, _) = mpsc::channel::<Cmd>();
         let (_, event_rx) = mpsc::channel::<Event>();
         Model {
-            document_source: SharedDocumentSource::test(),
             screen_size: (80, 20).into(),
             config: UserConfig::default().into(),
             scroll: 0,
@@ -664,6 +699,8 @@ mod tests {
             cmd_tx,
             event_rx,
             document_id: DocumentId::default(),
+            document_source: SharedDocumentSource::test(),
+            document_history: Vec::new(),
         }
     }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -10,9 +10,9 @@ use ghrepo::GHRepo;
 use reqwest::header::CONTENT_TYPE;
 use url::Url;
 
-use crate::{OK_END, VERSION, error::Error};
+use crate::{OK_END, VERSION, document::Document, error::Error};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DocumentSource {
     File {
         path: PathBuf,
@@ -26,6 +26,7 @@ pub enum DocumentSource {
     HyperText {
         url: Url,
     },
+    BuiltInHelp,
 }
 
 #[derive(Clone)]
@@ -37,8 +38,17 @@ impl SharedDocumentSource {
         SharedDocumentSource(Arc::new(RwLock::new(DocumentSource::Stdin)))
     }
 
-    pub fn read(&self) -> Result<DocumentSource, String> {
-        self.0.read().map(|g| g.clone()).map_err(|e| e.to_string())
+    pub fn read(&self) -> Result<DocumentSource, Error> {
+        self.0
+            .read()
+            .map(|g| g.clone())
+            .map_err(|e| Error::Thread(e.to_string()))
+    }
+
+    pub fn write(&self, source: DocumentSource) -> Result<(), Error> {
+        let mut inner = self.0.write().map_err(|e| Error::Thread(e.to_string()))?;
+        *inner = source;
+        Ok(())
     }
 }
 
@@ -185,4 +195,10 @@ pub fn extend_url(mut url: Url, path: &str) -> Result<String, Error> {
     url.set_fragment(path_url.fragment());
 
     Ok(url.to_string())
+}
+
+pub struct DocumentHistoryEntry {
+    pub source: DocumentSource,
+    pub document: Document,
+    pub scroll: u16,
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -214,7 +214,7 @@ pub fn view(model: &Model, frame: &mut Frame) {
             Cursor::Search(needle, _) => {
                 let mut line = Line::default();
                 line.spans.push(Span::from("/").fg(Color::Indexed(148)));
-                let needle = Span::from(needle.clone()).fg(Color::Indexed(148));
+                let needle = Span::from(needle.as_str()).fg(Color::Indexed(148));
                 line.spans.push(needle);
                 let width = line.width() as u16;
                 let searchbar = Paragraph::new(line);
@@ -225,7 +225,7 @@ pub fn view(model: &Model, frame: &mut Frame) {
         InputQueue::Search(needle) => {
             let mut line = Line::default();
             line.spans.push(Span::from("/").fg(Color::Indexed(148)));
-            let needle = Span::from(needle.clone());
+            let needle = Span::from(needle.as_str());
             line.spans.push(needle);
             let width = line.width() as u16;
             let searchbar = Paragraph::new(line);
@@ -247,6 +247,16 @@ pub fn view(model: &Model, frame: &mut Frame) {
         }
         InputQueue::CursorPositioningCommands => {
             let line = Line::from(Span::from("z").fg(Color::Indexed(32)));
+            let width = line.width() as u16;
+            let searchbar = Paragraph::new(line);
+            frame.render_widget(searchbar, Rect::new(0, status_line_y, width, 1));
+            frame.set_cursor_position((width, status_line_y));
+        }
+        InputQueue::Command(command) => {
+            let mut line = Line::default();
+            line.spans.push(Span::from(":").fg(Color::Indexed(148)));
+            let needle = Span::from(command.as_str());
+            line.spans.push(needle);
             let width = line.width() as u16;
             let searchbar = Paragraph::new(line);
             frame.render_widget(searchbar, Rect::new(0, status_line_y, width, 1));

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -227,7 +227,7 @@ pub fn worker_thread(
                         let event_tx = event_tx.clone();
                         tokio::task::spawn_blocking(move || -> Result<(), Error> {
                             if let Ok((text, _)) = open_source(&url, None) {
-                                event_tx.send(Event::NewSource(text))?;
+                                event_tx.send(Event::NewSourceContent(text))?;
                             }
                             Ok(())
                         })


### PR DESCRIPTION
Simply opens `help.md`. Adds general framework for commands, keeps a document history, adds a `:back` command.