### PR TITLE
fix(cli): print a friendly error when multiple sources are passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -858,8 +858,12 @@ Line that should be broken up later
 
     #[test]
     fn multiple_positional_sources_are_rejected_as_unknown_argument() {
-        // Lock the error kind and the offending value so the friendly
-        // message in `main` cannot silently regress to clap's default.
+        // Lock the error shape `main` keys off of for the friendly
+        // multi-positional hint: ErrorKind::UnknownArgument whose
+        // InvalidArg context is the second value (and therefore does
+        // not start with '-'). If clap ever changes how it reports
+        // extra positionals, `main` will silently fall back to its
+        // default error path and this test will surface that.
         use clap::error::{ContextKind, ErrorKind};
         let err = crate::build_cli()
             .try_get_matches_from(["mdfried", "a.md", "b.md"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use std::{
     },
 };
 
-use clap::{ArgMatches, arg, command, value_parser};
+use clap::{ArgMatches, Command, arg, command, error::ErrorKind, value_parser};
 use ratatui::{
     Terminal,
     crossterm::{
@@ -57,8 +57,8 @@ pub const OK_END: &str = " ok.";
 
 pub static VERSION: OnceLock<String> = OnceLock::new();
 
-fn main() -> io::Result<()> {
-    let mut cmd = command!() // requires `cargo` feature
+fn build_cli() -> Command {
+    command!() // requires `cargo` feature
         .arg(
             arg!([SOURCE] "The markdown source.\nCan be a file path, a URL, a github repo in \"github:[owner]/[repo]\" format, or '-' or omit, for stdin.")
         )
@@ -81,8 +81,35 @@ fn main() -> io::Result<()> {
                 .value_parser(value_parser!(String)),
         )
         .arg(arg!(--"animate" "Animate scrolling on startup (for demo recordings).").hide(true).value_parser(value_parser!(bool)))
-        ;
-    let matches = cmd.get_matches_mut();
+}
+
+fn main() -> io::Result<()> {
+    let mut cmd = build_cli();
+    let matches = match cmd.try_get_matches_from_mut(std::env::args_os()) {
+        Ok(m) => m,
+        Err(err) => {
+            // When the user passes more than one positional arg, clap reports
+            // `ErrorKind::UnknownArgument` for the second one. Detect that
+            // specific shape — the offending value does not start with `-` —
+            // and surface a hint that points at the most common cause: a
+            // shell glob like `mdfried **/*.md` that expanded to multiple
+            // paths. All other argument errors fall through to clap's
+            // default formatter, which already includes usage and `--help`.
+            let is_multi_positional = err.kind() == ErrorKind::UnknownArgument
+                && err
+                    .get(clap::error::ContextKind::InvalidArg)
+                    .is_some_and(|v| !format!("{v}").starts_with('-'));
+            if is_multi_positional {
+                eprintln!(
+                    "error: mdfried accepts a single source. \
+                     If you used a shell glob, quote it (e.g. mdfried '**/*.md') \
+                     or run mdfried once per file."
+                );
+                std::process::exit(2);
+            }
+            err.exit()
+        }
+    };
 
     if let Some(version) = cmd.get_version() {
         #[expect(unused_must_use)]
@@ -827,5 +854,22 @@ Line that should be broken up later
         );
 
         teardown(model, worker);
+    }
+
+    #[test]
+    fn multiple_positional_sources_are_rejected_as_unknown_argument() {
+        // Lock the error kind and the offending value so the friendly
+        // message in `main` cannot silently regress to clap's default.
+        use clap::error::{ContextKind, ErrorKind};
+        let err = crate::build_cli()
+            .try_get_matches_from(["mdfried", "a.md", "b.md"])
+            .expect_err("expected clap to reject more than one positional");
+        assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+        let invalid_arg = err.get(ContextKind::InvalidArg).map(|v| format!("{v}"));
+        assert_eq!(
+            invalid_arg.as_deref(),
+            Some("b.md"),
+            "expected the second positional to be reported as the invalid arg"
+        );
     }
 }


### PR DESCRIPTION
Closes #178

## What

When the user passes more than one positional argument (typically because
a shell glob like `mdfried **/PRO*.md` expanded to multiple paths),
clap returns `ErrorKind::UnknownArgument` for the second one. mdfried
now detects that specific shape — the offending value does not start
with `-` — and prints a friendly hint instead of clap's generic
'unexpected argument' message.

## Before

```text
$ mdfried a.md b.md
error: unexpected argument 'b.md' found

Usage: mdfried [OPTIONS] [SOURCE]

For more information, try '--help'.
```

## After

```text
$ mdfried a.md b.md
error: mdfried accepts a single source. If you used a shell glob, quote it
(e.g. mdfried '**/*.md') or run mdfried once per file.
```

Exit code stays `2` (matches clap's default for argument errors).

## Why

The `[SOURCE]` positional is correctly single-valued; the bug is purely
the error message. clap's default does not mention that mdfried takes
one source at a time, so users who reached for a glob to view several
PROPOSAL.md files get a wall of text that does not explain the actual
problem. Unknown flags (`--foo`) keep clap's normal error, since the
'single source' hint would be misleading there.

## How

- `build_cli()` is extracted from `main()` so the new unit test can
  call `try_get_matches_from` directly.
- `main()` now uses `try_get_matches_from_mut` instead of
  `get_matches_mut`, intercepts `ErrorKind::UnknownArgument` whose
  `InvalidArg` context does not start with `-`, prints the hint,
  and exits with `2`. All other argument errors fall through to
  `clap::error::Error::exit`, which keeps the well-tested usage /
  `--help` output for the cases that benefit from it.
- A unit test (`tests::multiple_positional_sources_are_rejected_as_unknown_argument`)
  locks the error kind and the offending value in, so the friendly
  message cannot silently regress to clap's default.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --no-default-features` — no new warnings
  (the two `#[allow(...)] on document.rs` warnings pre-exist on master
  and are unrelated)
- `cargo build --no-default-features`
- `cargo build --release --no-default-features`
- `cargo test --no-default-features --bin mdfried` — new test passes;
  the only failures are the pre-existing `insta` snapshot tests that
  also fail on base master
- `cargo doc --no-deps`
- End-to-end check on the release binary:
  `mdfried a.md b.md` → friendly message, exit 2
  `mdfried --nope` → clap's default error, exit 2
  `mdfried --print-config` → still works