### PR TITLE
feat(cli): render multiple source files in one session

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -508,6 +508,15 @@ pub enum SectionContent {
     HeaderPlaceholder(String, u8, Vec<(Line<'static>, Vec<LineExtra>)>),
     Lines(Vec<(Line<'static>, Vec<LineExtra>)>),
     Code(String, Vec<(Line<'static>, Vec<LineExtra>)>),
+    /// Visual separator between files in multi-source mode.
+    ///
+    /// Carries the path the user passed on the command line (verbatim) so the
+    /// rendered header mirrors what they typed in their shell glob. The view
+    /// layer renders this as a single muted line of the form
+    /// `── File: <name> ──…` filling the rest of the inner width.
+    FileSeparator {
+        filename: String,
+    },
 }
 
 impl SectionContent {
@@ -585,6 +594,9 @@ impl Debug for SectionContent {
             Self::Code(language, lines) => {
                 f.debug_tuple("Code").field(language).field(lines).finish()
             }
+            Self::FileSeparator { filename } => {
+                f.debug_tuple("FileSeparator").field(filename).finish()
+            }
         }
     }
 }
@@ -602,6 +614,7 @@ impl Display for SectionContent {
             Self::Header(text, tier, _) => write!(f, "Header({text}, {tier})"),
             Self::HeaderPlaceholder(_, _, lines) => write!(f, "HeaderPlaceholder({lines:?})"),
             Self::Code(language, lines) => write!(f, "Code({language}, {lines:?})"),
+            Self::FileSeparator { filename } => write!(f, "FileSeparator({filename})"),
         }
     }
 }
@@ -648,6 +661,9 @@ impl Display for Section {
                     write!(f, "{}", line)?;
                 }
                 Ok(())
+            }
+            SectionContent::FileSeparator { filename } => {
+                write!(f, "<file-separator: {filename}>")
             }
         }
     }
@@ -880,6 +896,7 @@ pub async fn image_section(
     max_height: u16,
     width: u16,
     document_source: SharedDocumentSource,
+    basepath_override: Option<&std::path::Path>,
     client: Arc<RwLock<Client>>,
     id: SectionID,
     link: MarkdownLink,
@@ -890,29 +907,34 @@ pub async fn image_section(
     let image_source = if link_url.starts_with("https://") || link_url.starts_with("http://") {
         download_image(client, fontdb, link_url).await?
     } else {
-        let image_source: Option<ImageSource> = match document_source.read() {
-            Ok(DocumentSource::File {
-                basepath: Some(basepath),
-                ..
-            }) => {
-                let path = basepath.join(link_url).to_str().map(String::from);
-                path.map(ImageSource::Path)
-            }
-            Ok(DocumentSource::Github { repo, branch }) => {
-                if let Ok(repo_url) = github_usercontent_url(&repo, &branch, link_url) {
-                    Some(download_image(client, fontdb, repo_url.as_str()).await?)
-                } else {
-                    None
+        let image_source: Option<ImageSource> = if let Some(basepath) = basepath_override {
+            let path = basepath.join(link_url).to_str().map(String::from);
+            path.map(ImageSource::Path)
+        } else {
+            match document_source.read() {
+                Ok(DocumentSource::File {
+                    basepath: Some(basepath),
+                    ..
+                }) => {
+                    let path = basepath.join(link_url).to_str().map(String::from);
+                    path.map(ImageSource::Path)
                 }
-            }
-            Ok(DocumentSource::HyperText { url }) => {
-                if let Ok(extended_url) = extend_url(url.clone(), link_url) {
-                    Some(download_image(client, fontdb, extended_url.as_str()).await?)
-                } else {
-                    None
+                Ok(DocumentSource::Github { repo, branch }) => {
+                    if let Ok(repo_url) = github_usercontent_url(&repo, &branch, link_url) {
+                        Some(download_image(client, fontdb, repo_url.as_str()).await?)
+                    } else {
+                        None
+                    }
                 }
+                Ok(DocumentSource::HyperText { url }) => {
+                    if let Ok(extended_url) = extend_url(url.clone(), link_url) {
+                        Some(download_image(client, fontdb, extended_url.as_str()).await?)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
             }
-            _ => None,
         };
         image_source.unwrap_or_else(|| ImageSource::Path(link_url.to_owned()))
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,30 +155,33 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
     if sources.iter().filter(|s| s.as_str() == "-").count() > 1 {
         return Err(Error::Usage(Some("stdin ('-') can only be used once")));
     }
-    for source in &sources {
-        if source.starts_with("http://")
-            || source.starts_with("https://")
-            || source.starts_with("github:")
-        {
+
+    // Detect multi-file mode up front so all the source-list validation can
+    // happen *before* any I/O. Single-source URLs and github: paths are
+    // still routed through `open_source(...)` below.
+    let is_multi_file = sources.len() > 1 && sources.iter().any(|s| s.as_str() != "-");
+
+    if is_multi_file {
+        if sources.iter().any(|s| s.as_str() == "-") {
             return Err(Error::Usage(Some(
-                "URLs and github repositories are not yet supported alongside file paths; pass only file paths (or a single '-') for now",
+                "stdin ('-') cannot be mixed with file paths",
             )));
         }
+        for source in &sources {
+            if source.starts_with("http://")
+                || source.starts_with("https://")
+                || source.starts_with("github:")
+            {
+                return Err(Error::Usage(Some(
+                    "URLs and github repositories are not yet supported alongside file paths; pass only file paths for now",
+                )));
+            }
+        }
     }
-
-    // Detect multi-file mode: more than one source, and at least one is a
-    // non-stdin path. Mixed stdin + files is already rejected above; mixed
-    // stdin alone is the existing single-source stdin flow.
-    let is_multi_file = sources.len() > 1 && sources.iter().any(|s| s.as_str() != "-");
 
     let (text, document_source) = if is_multi_file {
         let mut entries = Vec::with_capacity(sources.len());
         for source in &sources {
-            if source == "-" {
-                return Err(Error::Usage(Some(
-                    "stdin ('-') cannot be mixed with file paths",
-                )));
-            }
             print!("Reading {source}...");
             let path = PathBuf::from(source);
             let text = std::fs::read_to_string(&path).map_err(|err| {
@@ -510,7 +513,11 @@ impl std::fmt::Debug for Event {
 #[cfg(test)]
 #[expect(clippy::unwrap_used)]
 mod tests {
-    use std::{path::PathBuf, sync::{Arc, mpsc}, thread::JoinHandle};
+    use std::{
+        path::PathBuf,
+        sync::{Arc, mpsc},
+        thread::JoinHandle,
+    };
 
     #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
     use insta::assert_snapshot;
@@ -961,11 +968,8 @@ Line that should be broken up later
             screen_size,
             Config::from(UserConfig::default()),
         );
-        let mut terminal = Terminal::new(TestBackend::new(
-            screen_size.width,
-            screen_size.height,
-        ))
-        .unwrap();
+        let mut terminal =
+            Terminal::new(TestBackend::new(screen_size.width, screen_size.height)).unwrap();
         model.parse_multi(entries).expect("parse_multi");
         poll_parsed(&mut model);
 
@@ -1002,13 +1006,7 @@ Line that should be broken up later
             for y in 0..buffer.area.height {
                 let mut line = String::new();
                 for x in 0..buffer.area.width {
-                    line.push(
-                        buffer[(x, y)]
-                            .symbol()
-                            .chars()
-                            .next()
-                            .unwrap_or(' '),
-                    );
+                    line.push(buffer[(x, y)].symbol().chars().next().unwrap_or(' '));
                 }
                 if line.contains("File: first.md") {
                     found_separator_line = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use crate::{
     error::Error,
     model::{DocumentId, Model},
     renderer::run_loop,
-    sources::{BuiltIn, DocumentSource, SharedDocumentSource, open_source},
+    sources::{BuiltIn, DocumentSource, MultiFileEntry, SharedDocumentSource, open_source},
     watch::watch,
     worker::{ImageCache, worker_thread},
 };
@@ -60,7 +60,7 @@ pub static VERSION: OnceLock<String> = OnceLock::new();
 fn main() -> io::Result<()> {
     let mut cmd = command!() // requires `cargo` feature
         .arg(
-            arg!([SOURCE] "The markdown source.\nCan be a file path, a URL, a github repo in \"github:[owner]/[repo]\" format, or '-' or omit, for stdin.")
+            arg!([SOURCES]... "The markdown source(s).\nOne or more file paths. Multiple files are rendered in sequence, separated by a header. Pass '-' for stdin, or omit entirely to read stdin / show the welcome screen. URLs and github repositories are not yet supported alongside local files.")
         )
         .arg(arg!(-d --"deep-fry" "Extra deep fried images.").value_parser(value_parser!(bool)))
         .arg(arg!(-w --"watch" "Watch markdown file, reload on changes.").value_parser(value_parser!(bool)))
@@ -136,31 +136,90 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
     let log = matches.get_one::<String>("log");
     debug::init_logger(debug::LogTarget::from(log))?;
 
-    let source: Option<String> = matches.get_one::<String>("SOURCE").cloned();
+    let sources: Vec<String> = matches
+        .get_many::<String>("SOURCES")
+        .map(|v| v.cloned().collect())
+        .unwrap_or_default();
 
     let mut user_config = config::load_or_ask()?;
     let mut config = Config::from(user_config.clone());
 
-    let (text, document_source) = match source {
-        Some(source) if source == "-" => {
-            let mut text = String::new();
-            print!("Reading stdin...");
-            io::stdin().read_to_string(&mut text)?;
-            println!("{OK_END}");
-            (text, DocumentSource::Stdin { text: None })
+    // Validate the source list before doing any I/O so the user gets a clear
+    // error instead of e.g. a partial file read.
+    let watch_requested = *matches.get_one("watch").unwrap_or(&false);
+    if watch_requested && sources.len() > 1 {
+        return Err(Error::Usage(Some(
+            "--watch is only supported with a single source",
+        )));
+    }
+    if sources.iter().filter(|s| s.as_str() == "-").count() > 1 {
+        return Err(Error::Usage(Some("stdin ('-') can only be used once")));
+    }
+    for source in &sources {
+        if source.starts_with("http://")
+            || source.starts_with("https://")
+            || source.starts_with("github:")
+        {
+            return Err(Error::Usage(Some(
+                "URLs and github repositories are not yet supported alongside file paths; pass only file paths (or a single '-') for now",
+            )));
         }
-        None => {
-            if io::stdin().is_tty() {
-                (String::new(), DocumentSource::BuiltIn(BuiltIn::Welcome))
-            } else {
+    }
+
+    // Detect multi-file mode: more than one source, and at least one is a
+    // non-stdin path. Mixed stdin + files is already rejected above; mixed
+    // stdin alone is the existing single-source stdin flow.
+    let is_multi_file = sources.len() > 1 && sources.iter().any(|s| s.as_str() != "-");
+
+    let (text, document_source) = if is_multi_file {
+        let mut entries = Vec::with_capacity(sources.len());
+        for source in &sources {
+            if source == "-" {
+                return Err(Error::Usage(Some(
+                    "stdin ('-') cannot be mixed with file paths",
+                )));
+            }
+            print!("Reading {source}...");
+            let path = PathBuf::from(source);
+            let text = std::fs::read_to_string(&path).map_err(|err| {
+                println!(" error.");
+                Error::Io(err)
+            })?;
+            println!("{OK_END}");
+            let basepath = path.parent().map(std::path::Path::to_path_buf);
+            entries.push(MultiFileEntry {
+                path,
+                basepath,
+                text,
+            });
+        }
+        // The model does not need a single combined text for the
+        // `Event::ParseDone` payload, but we pass an empty string to keep
+        // the existing `DocumentSource::Stdin`-style reload path inert in
+        // the multi-file branch.
+        (String::new(), DocumentSource::MultiFile { entries })
+    } else {
+        match sources.first().map(String::as_str) {
+            Some("-") => {
                 let mut text = String::new();
                 print!("Reading stdin...");
                 io::stdin().read_to_string(&mut text)?;
                 println!("{OK_END}");
                 (text, DocumentSource::Stdin { text: None })
             }
+            None => {
+                if io::stdin().is_tty() {
+                    (String::new(), DocumentSource::BuiltIn(BuiltIn::Welcome))
+                } else {
+                    let mut text = String::new();
+                    print!("Reading stdin...");
+                    io::stdin().read_to_string(&mut text)?;
+                    println!("{OK_END}");
+                    (text, DocumentSource::Stdin { text: None })
+                }
+            }
+            Some(source) => open_source(source, config.url_transform_command.clone())?,
         }
-        Some(source) => open_source(&source, config.url_transform_command.clone())?,
     };
 
     if text.is_empty()
@@ -169,6 +228,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
             DocumentSource::BuiltIn(BuiltIn::Welcome)
                 | DocumentSource::Image { .. }
                 | DocumentSource::Pdf { .. }
+                | DocumentSource::MultiFile { .. }
         )
     {
         return Err(Error::Usage(Some("no input or empty")));
@@ -276,7 +336,22 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
         cmd_tx.send(Cmd::LoadImage(None))?;
     }
     let model = Model::new(document_source, cmd_tx, event_rx, terminal.size()?, config);
-    model.open(text)?;
+    if is_multi_file {
+        // Pull the entries out of the shared document_source (we still keep
+        // the `DocumentSource::MultiFile` in there for `open_link` and other
+        // code paths that inspect the current source).
+        let DocumentSource::MultiFile { entries } = model
+            .document_source()
+            .ok_or_else(|| Error::Generic("multi-file document_source missing".to_owned()))?
+        else {
+            return Err(Error::Generic(
+                "expected DocumentSource::MultiFile in multi-file mode".to_owned(),
+            ));
+        };
+        model.parse_multi(entries)?;
+    } else {
+        model.open(text)?;
+    }
 
     let debouncer = if let Some(path) = watchmode_path {
         log::info!("watching file");
@@ -309,6 +384,7 @@ fn main_with_args(matches: &ArgMatches) -> Result<(), Error> {
 
 pub enum Cmd {
     Parse(DocumentId, u16, String, Option<ImageCache>),
+    ParseMulti(DocumentId, u16, Vec<MultiFileEntry>, Option<ImageCache>),
     OpenUrl(String),
     LoadImage(Option<(PathBuf, Size)>), // TODO: either included welcome logo, or a path, make an enum?
     LoadPdf(PathBuf, Size),
@@ -327,6 +403,13 @@ impl Display for Cmd {
                 write!(
                     f,
                     "Cmd::Parse({reload_id:?}, {width}, <text>, cache={cache:?})",
+                )
+            }
+            Cmd::ParseMulti(reload_id, width, entries, cache) => {
+                write!(
+                    f,
+                    "Cmd::ParseMulti({reload_id:?}, {width}, {} entries, cache={cache:?})",
+                    entries.len(),
                 )
             }
             Cmd::OpenUrl(url) => write!(f, "Cmd::Open({url})"),
@@ -427,7 +510,7 @@ impl std::fmt::Debug for Event {
 #[cfg(test)]
 #[expect(clippy::unwrap_used)]
 mod tests {
-    use std::{sync::mpsc, thread::JoinHandle};
+    use std::{path::PathBuf, sync::{Arc, mpsc}, thread::JoinHandle};
 
     #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
     use insta::assert_snapshot;
@@ -440,7 +523,7 @@ mod tests {
         document::{Section, SectionContent},
         error::Error,
         model::Model,
-        sources::SharedDocumentSource,
+        sources::{DocumentSource, MultiFileEntry, SharedDocumentSource},
         view::view,
         worker::worker_thread,
     };
@@ -824,6 +907,130 @@ Line that should be broken up later
                 (Line::from("broken up later"), Vec::new()),
             ]),
             sections[5].content
+        );
+
+        teardown(model, worker);
+    }
+
+    /// Build a model whose `document_source` is `MultiFile`, send a
+    /// `ParseMulti` for two trivial markdown files, and assert that the
+    /// resulting section list contains a `FileSeparator` between the two
+    /// files' content, with the user-provided path verbatim in the separator.
+    #[test]
+    fn multi_file_renders_with_file_separator() {
+        let entries = vec![
+            MultiFileEntry {
+                path: PathBuf::from("first.md"),
+                basepath: None,
+                text: String::from("# First\n\nFirst file body.\n"),
+            },
+            MultiFileEntry {
+                path: PathBuf::from("subdir/second.md"),
+                basepath: Some(PathBuf::from("subdir")),
+                text: String::from("# Second\n\nSecond file body.\n"),
+            },
+        ];
+
+        // Build a Model whose document_source is MultiFile, mirroring what
+        // `main_with_args` does in the new multi-file branch.
+        let (cmd_tx, cmd_rx) = mpsc::channel::<Cmd>();
+        let (event_tx, event_rx) = mpsc::channel::<Event>();
+        let picker = Picker::halfblocks();
+        let mut worker_config: Config = UserConfig::default().into();
+        worker_config.theme.has_text_size_protocol = Some(true);
+        let document_source = SharedDocumentSource(Arc::new(std::sync::RwLock::new(
+            DocumentSource::MultiFile {
+                entries: entries.clone(),
+            },
+        )));
+        let worker = worker_thread(
+            document_source.clone(),
+            picker,
+            None,
+            worker_config,
+            false,
+            cmd_rx,
+            event_tx,
+            20,
+        );
+        let screen_size: Size = (80, 20).into();
+        let mut model = Model::new(
+            document_source,
+            cmd_tx,
+            event_rx,
+            screen_size,
+            Config::from(UserConfig::default()),
+        );
+        let mut terminal = Terminal::new(TestBackend::new(
+            screen_size.width,
+            screen_size.height,
+        ))
+        .unwrap();
+        model.parse_multi(entries).expect("parse_multi");
+        poll_parsed(&mut model);
+
+        let sections: Vec<&Section> = model.sections().collect();
+
+        // Expect: FileSeparator(first.md) -> Lines(first content) ->
+        // FileSeparator(second.md) -> Lines(second content).
+        assert!(
+            sections.iter().any(|s| matches!(
+                &s.content,
+                SectionContent::FileSeparator { filename } if filename == "first.md"
+            )),
+            "missing FileSeparator for first.md; got: {sections:?}"
+        );
+        assert!(
+            sections.iter().any(|s| matches!(
+                &s.content,
+                SectionContent::FileSeparator { filename } if filename == "subdir/second.md"
+            )),
+            "missing FileSeparator for subdir/second.md; got: {sections:?}"
+        );
+
+        // Render into the test buffer and assert the separator line shows
+        // up as the muted bat-style line we want.
+        terminal
+            .draw(|frame| {
+                view(&model, frame.buffer_mut());
+            })
+            .expect("draw");
+        let mut found_separator_line = false;
+        {
+            let backend = terminal.backend();
+            let buffer = backend.buffer().clone();
+            for y in 0..buffer.area.height {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push(
+                        buffer[(x, y)]
+                            .symbol()
+                            .chars()
+                            .next()
+                            .unwrap_or(' '),
+                    );
+                }
+                if line.contains("File: first.md") {
+                    found_separator_line = true;
+                    // The line must use the same ─ character that bat uses.
+                    assert!(
+                        line.contains('\u{2500}'),
+                        "separator line for first.md missing the bat-style rule; got: {line:?}"
+                    );
+                }
+                if line.contains("File: subdir/second.md") {
+                    // Second separator must also use the bat-style rule, and
+                    // the user-supplied path must be preserved verbatim.
+                    assert!(
+                        line.contains('\u{2500}'),
+                        "separator line for subdir/second.md missing the bat-style rule; got: {line:?}"
+                    );
+                }
+            }
+        }
+        assert!(
+            found_separator_line,
+            "expected a 'File: first.md' separator line in the rendered buffer",
         );
 
         teardown(model, worker);

--- a/src/model.rs
+++ b/src/model.rs
@@ -153,6 +153,23 @@ impl Model {
         self.parse(self.document_id.open(), text, None)
     }
 
+    /// Send a multi-file parse to the worker.
+    ///
+    /// Each `MultiFileEntry`'s text is parsed in order, with a
+    /// `SectionContent::FileSeparator` rendered between files. The worker
+    /// takes care of attributing each image link to the right file's
+    /// basepath so relative `![](img.png)` references resolve correctly.
+    pub fn parse_multi(&self, entries: Vec<crate::sources::MultiFileEntry>) -> Result<(), Error> {
+        let inner_width = self.config.padding.calculate_width(self.screen_size.width);
+        self.cmd_tx.send(Cmd::ParseMulti(
+            self.document_id.open(),
+            inner_width,
+            entries,
+            None,
+        ))?;
+        Ok(())
+    }
+
     fn open_new_source(&mut self, source: DocumentSource, text: String) -> Result<(), Error> {
         self.document_history.push(DocumentHistoryEntry {
             source: self.document_source.read()?,
@@ -495,6 +512,15 @@ impl Model {
             DocumentSource::Image { .. } | DocumentSource::Pdf { .. } => {
                 return Err(Error::Navigation(NavigationError::UnknownLinkType(
                     link_url,
+                )));
+            }
+            DocumentSource::MultiFile { .. } => {
+                // Multi-file mode is a read-only batch view; there is no concept
+                // of "open the current document" because there are several. v1
+                // surfaces this as an explicit error so users see why their
+                // click did not navigate, instead of silently doing nothing.
+                return Err(Error::Navigation(NavigationError::UnknownLinkType(
+                    "multi-file mode does not support link navigation".to_owned(),
                 )));
             }
         }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -17,6 +17,14 @@ use crate::{
     error::{Error, NavigationError},
 };
 
+/// One entry in a [`DocumentSource::MultiFile`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct MultiFileEntry {
+    pub path: PathBuf,
+    pub basepath: Option<PathBuf>,
+    pub text: String,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum DocumentSource {
     File {
@@ -40,6 +48,9 @@ pub enum DocumentSource {
     Pdf {
         path: PathBuf,
     },
+    MultiFile {
+        entries: Vec<MultiFileEntry>,
+    },
 }
 
 impl DocumentSource {
@@ -50,6 +61,7 @@ impl DocumentSource {
             }),
             // TODO: Github and HyperText should also return the text to avoid re-fetch.
             // File is OK to just reload from disk.
+            // MultiFile carries its text per-entry; the model already has what it needs.
             _ => None,
         }
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -110,6 +110,25 @@ pub fn view(model: &Model, buf: &mut Buffer) -> Option<Position> {
                 }
                 y += 1;
             }
+            SectionContent::FileSeparator { filename } => {
+                if y >= 0 && (y as u16) < inner_area.height.saturating_sub(1) {
+                    let inner_w = inner_area.width as usize;
+                    let prefix =
+                        format!("\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} File: {filename} ");
+                    let mut line = String::with_capacity(inner_w);
+                    line.push_str(&prefix);
+                    if line.len() < inner_w {
+                        for _ in 0..(inner_w - line.len()) {
+                            line.push('\u{2500}');
+                        }
+                    } else {
+                        line.truncate(inner_w);
+                    }
+                    let p = Paragraph::new(line).fg(Color::DarkGray);
+                    render_lines(p, 1, y as u16, inner_area, buf);
+                }
+                y += 1;
+            }
         }
         if y >= inner_area.height as i32 - 1 {
             // Do not render into last line, nor beyond area.

--- a/src/view.rs
+++ b/src/view.rs
@@ -113,16 +113,25 @@ pub fn view(model: &Model, buf: &mut Buffer) -> Option<Position> {
             SectionContent::FileSeparator { filename } => {
                 if y >= 0 && (y as u16) < inner_area.height.saturating_sub(1) {
                     let inner_w = inner_area.width as usize;
+                    // `inner_w` is a terminal cell width, so all width
+                    // math has to be in display columns — the rule
+                    // character (\u{2500}) and any non-ASCII characters in
+                    // the user's filename can otherwise land us mid-UTF-8
+                    // sequence and panic `String::truncate`.
                     let prefix =
                         format!("\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} File: {filename} ");
-                    let mut line = String::with_capacity(inner_w);
-                    line.push_str(&prefix);
-                    if line.len() < inner_w {
-                        for _ in 0..(inner_w - line.len()) {
+                    let prefix_w = prefix.width();
+                    let mut line = prefix;
+                    if prefix_w < inner_w {
+                        for _ in 0..(inner_w - prefix_w) {
                             line.push('\u{2500}');
                         }
                     } else {
-                        line.truncate(inner_w);
+                        // Trim trailing chars until the display width fits
+                        // `inner_w`. Never split a multi-byte codepoint.
+                        while line.width() > inner_w {
+                            line.pop();
+                        }
                     }
                     let p = Paragraph::new(line).fg(Color::DarkGray);
                     render_lines(p, 1, y as u16, inner_area, buf);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -172,7 +172,6 @@ pub fn worker_thread(
                             event_tx.send(Event::NewDocument(document_id))?;
                             let mut all_post_parse_events: Vec<SectionEvent> = Vec::new();
                             let mut last_section_id: Option<usize> = None;
-                            let mut all_text = String::new();
                             let mut image_cache = image_cache.unwrap_or_default();
                             let has_renderer = thread_renderer.is_some();
                             // Section ids are unique per parsed document. Each file
@@ -212,7 +211,6 @@ pub fn worker_thread(
                                 next_section_id = file_next_id;
                                 last_section_id = file_next_id.checked_sub(1).or(last_section_id);
                                 all_post_parse_events.append(&mut file_events);
-                                all_text.push_str(&text);
                             }
 
                             let uncached_post_parse_events = drain_image_cache(
@@ -224,10 +222,15 @@ pub fn worker_thread(
                                 all_post_parse_events,
                             )?;
 
+                            // `Event::ParseDone`'s text payload is only
+                            // consumed by `DocumentSource::Stdin::return_text`,
+                            // which is not used in multi-file mode, so we
+                            // pass an empty string to avoid duplicating
+                            // every input file in memory.
                             event_tx.send(Event::ParseDone(
                                 document_id,
                                 last_section_id,
-                                all_text,
+                                String::new(),
                             ))?;
 
                             if !uncached_post_parse_events.is_empty() {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,7 @@ pub mod sections;
 
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{
         Arc,
         mpsc::{Receiver, Sender},
@@ -31,12 +32,13 @@ use crate::{
     Cmd, Event, Protocol, VERSION,
     config::{Config, MermaidConfig},
     document::{
-        LineExtra, LinkReference, SectionContent, header_images, header_sections, image_section,
+        LineExtra, LinkReference, Section, SectionContent, header_images, header_sections,
+        image_section,
     },
     error::Error,
     model::DocumentId,
     setup::FontRenderer,
-    sources::{SharedDocumentSource, open_source},
+    sources::{MultiFileEntry, SharedDocumentSource, open_source},
     worker::{
         highlighter::Highlighter,
         sections::{SectionEvent, SectionIterator},
@@ -60,7 +62,6 @@ pub fn worker_thread(
             .enable_all()
             .build()?;
         let result = runtime.block_on(async {
-
             let builder = Client::builder().user_agent(format!(
                 "mdfried/{}",
                 VERSION.get().unwrap_or(&"unknown".to_owned())
@@ -86,7 +87,8 @@ pub fn worker_thread(
                 .map(|fr| {
                     let db = fr.font_system.db();
                     Arc::new(db.clone())
-                }).or_else(|| {
+                })
+                .or_else(|| {
                     #[cfg(test)]
                     {
                         // Making the font db fails some tests, maybe takes too long.
@@ -96,7 +98,9 @@ pub fn worker_thread(
                     #[cfg(not(test))]
                     {
                         if !config.theme.has_text_size_protocol.unwrap_or_default() {
-                            log::warn!("loading system fonts for SVG despite not using text-size-protocol");
+                            log::warn!(
+                                "loading system fonts for SVG despite not using text-size-protocol"
+                            );
                         }
                         let mut fontdb = Database::new();
                         fontdb.load_system_fonts(); // loads all system fonts
@@ -121,113 +125,30 @@ pub fn worker_thread(
                         Cmd::Parse(document_id, width, text, image_cache) => {
                             event_tx.send(Event::NewDocument(document_id))?;
 
-                            let lines = parser.parse(width, &text, &config.theme)?;
-                            let mut section_iter = SectionIterator::new(lines, &config.theme);
-                            let mut post_parse_events = Vec::new();
-                            for section in &mut section_iter {
-                                match &section.content {
-                                    SectionContent::Lines(lines) => {
-                                        for (_, extras) in lines {
-                                            for extra in extras {
-                                                if let LineExtra::Link { reference, .. } = extra
-                                                    && let LinkReference::ReferenceDefinition{ id, url } = reference {
-                                                        post_parse_events.push(SectionEvent::ReferenceDefinition{ id: id.clone(), url: url.clone() });
-                                                }
-                                            }
-                                        }
-                                        event_tx.send(Event::Parsed(document_id, section))?;
-                                    }
-                                    SectionContent::Code(language, lines) => {
-                                        post_parse_events.push(SectionEvent::Code(section.id, language.clone(), lines.iter().map(|(line,_)| line.clone()).collect()));
-                                        event_tx.send(Event::Parsed(document_id, section))?;
-                                    }
-                                    SectionContent::Image(_, _,_,_) => {
-                                        unreachable!("SectionIterator produced Image");
-                                    }
-                                    SectionContent::ImagePlaceholder(link, lines) => {
-                                        let section_id = section.id;
-                                        let link = link.clone();
-                                        let has_trailing_blank = lines.last().map(|(line,_)| line.spans.is_empty()).unwrap_or_default();
-                                        event_tx.send(Event::Parsed(document_id, section))?;
-                                        post_parse_events.push(SectionEvent::Image(section_id, link, has_trailing_blank));
-                                    },
-                                    SectionContent::Header(_, _, _) => {
-                                        if !config.theme.has_text_size_protocol.unwrap_or_default() {
-                                            unreachable!("SectionIterator produced Header without text-size-protocol");
-                                        }
-                                        event_tx.send(Event::Parsed(document_id, section))?;
-                                    }
-                                    SectionContent::HeaderPlaceholder(text,tier,_) => {
-                                        if config.theme.has_text_size_protocol.unwrap_or_default() {
-                                            unreachable!("SectionIterator produced HeaderPlaceholder with text-size-protocol");
-                                        }
-                                        let section_id = section.id;
-                                        let text = text.clone();
-                                        let tier = *tier;
-                                        event_tx.send(Event::Parsed(document_id, section))?;
-                                        if thread_renderer.is_some() {
-                                            post_parse_events.push(SectionEvent::Header(section_id, text, tier));
-                                        }
-                                    }
-                                }
-                            }
-                            let section_id = section_iter.last_section_id();
-                            drop(section_iter);
+                            let (next_section_id, post_parse_events) = parse_one_file(
+                                &mut parser,
+                                &event_tx,
+                                document_id,
+                                width,
+                                &text,
+                                None,
+                                thread_renderer.is_some(),
+                                &config,
+                                0,
+                            )?;
+                            let last_section_id = next_section_id.checked_sub(1);
 
-                            // Send cached images synchronously before ParseDone
                             let mut image_cache = image_cache.unwrap_or_default();
-                            let mut uncached_post_parse_events = Vec::new();
-                            for event in post_parse_events {
-                                match &event {
-                                    SectionEvent::Image(
-                                        section_id,
-                                        link,
-                                        has_trailing_blank,
-                                    ) => {
-                                        if let Some((proto, size, max_size)) = image_cache.images.remove(&link.url) {
-                                            if width == max_size.width && config_max_image_height >= max_size.height {
-                                                event_tx.send(Event::ImageLoaded(
-                                                    document_id,
-                                                    *section_id,
-                                                    link.clone(),
-                                                    (proto, size, max_size),
-                                                    *has_trailing_blank,
-                                                ))?;
-                                                log::debug!("image cache hit: {max_size:?} vs {width}x{config_max_image_height}, {size:?}, {}", link.url);
-                                            } else {
-                                                log::debug!("image cache hit but different max width ({width}x{config_max_image_height} vs {max_size}): {size:?}, {}", link.url);
-                                                uncached_post_parse_events.push(event);
-                                            }
-                                        } else {
-                                            log::debug!("image cache miss: {}", link.url);
-                                            uncached_post_parse_events.push(event);
-                                        }
-                                    }
-                                    SectionEvent::Header(section_id, text, tier) => {
-                                        let key = (text.clone(), *tier);
-                                        if let Some(protos) = image_cache.headers(width).and_then(|hc| hc.remove(&key)) {
-                                            log::debug!("header cache hit: {key:?}");
-                                            event_tx.send(Event::HeaderLoaded(
-                                                document_id,
-                                                *section_id,
-                                                protos
-                                                    .into_iter()
-                                                    .map(|proto| (text.clone(), *tier, proto))
-                                                    .collect(),
-                                            ))?;
-                                        } else {
-                                            log::debug!("header cache miss: {key:?}");
-                                            uncached_post_parse_events.push(event);
-                                        }
-                                    }
-                                    SectionEvent::ReferenceDefinition { id, url } => {
-                                        event_tx.send(Event::ReferenceDefinition { id: format!("[{id}]"), url: url.clone() })?;
-                                    }
-                                    _ => uncached_post_parse_events.push(event),
-                                }
-                            }
+                            let uncached_post_parse_events = drain_image_cache(
+                                &event_tx,
+                                document_id,
+                                width,
+                                &mut image_cache,
+                                config_max_image_height,
+                                post_parse_events,
+                            )?;
 
-                            event_tx.send(Event::ParseDone(document_id, section_id, text))?;
+                            event_tx.send(Event::ParseDone(document_id, last_section_id, text))?;
 
                             if !uncached_post_parse_events.is_empty() {
                                 process_post_parse_events(
@@ -243,7 +164,88 @@ pub fn worker_thread(
                                     deep_fry,
                                     document_id,
                                     uncached_post_parse_events,
-                                ).await?;
+                                )
+                                .await?;
+                            }
+                        }
+                        Cmd::ParseMulti(document_id, width, entries, image_cache) => {
+                            event_tx.send(Event::NewDocument(document_id))?;
+                            let mut all_post_parse_events: Vec<SectionEvent> = Vec::new();
+                            let mut last_section_id: Option<usize> = None;
+                            let mut all_text = String::new();
+                            let mut image_cache = image_cache.unwrap_or_default();
+                            let has_renderer = thread_renderer.is_some();
+                            // Section ids are unique per parsed document. Each file
+                            // (and the FileSeparator that precedes it) needs an id,
+                            // so the worker keeps a counter that survives across the
+                            // per-file parse loops.
+                            let mut next_section_id: usize = 0;
+
+                            for MultiFileEntry {
+                                path,
+                                basepath,
+                                text,
+                            } in entries
+                            {
+                                let display_name = path.display().to_string();
+                                let separator_section = Section {
+                                    id: next_section_id,
+                                    height: 1,
+                                    content: SectionContent::FileSeparator {
+                                        filename: display_name,
+                                    },
+                                };
+                                next_section_id += 1;
+                                event_tx.send(Event::Parsed(document_id, separator_section))?;
+
+                                let (file_next_id, mut file_events) = parse_one_file(
+                                    &mut parser,
+                                    &event_tx,
+                                    document_id,
+                                    width,
+                                    &text,
+                                    basepath.as_deref(),
+                                    has_renderer,
+                                    &config,
+                                    next_section_id,
+                                )?;
+                                next_section_id = file_next_id;
+                                last_section_id = file_next_id.checked_sub(1).or(last_section_id);
+                                all_post_parse_events.append(&mut file_events);
+                                all_text.push_str(&text);
+                            }
+
+                            let uncached_post_parse_events = drain_image_cache(
+                                &event_tx,
+                                document_id,
+                                width,
+                                &mut image_cache,
+                                config_max_image_height,
+                                all_post_parse_events,
+                            )?;
+
+                            event_tx.send(Event::ParseDone(
+                                document_id,
+                                last_section_id,
+                                all_text,
+                            ))?;
+
+                            if !uncached_post_parse_events.is_empty() {
+                                process_post_parse_events(
+                                    event_tx.clone(),
+                                    document_source.clone(),
+                                    client.clone(),
+                                    thread_picker.clone(),
+                                    thread_renderer.clone(),
+                                    fontdb.clone(),
+                                    highlighter.clone(),
+                                    width,
+                                    &config,
+                                    deep_fry,
+                                    document_id,
+                                    uncached_post_parse_events,
+                                )
+                                .await?;
                             }
                         }
                         Cmd::OpenUrl(url) => {
@@ -258,51 +260,65 @@ pub fn worker_thread(
                         }
                         #[cfg(not(feature = "pdf"))]
                         Cmd::LoadPdf(_path, _available) => {
-                            return Err(Error::Usage(Some("PDF support has not been enabled at build")));
+                            return Err(Error::Usage(Some(
+                                "PDF support has not been enabled at build",
+                            )));
                         }
                         #[cfg(feature = "pdf")]
                         Cmd::LoadPdf(path, available) => {
                             let event_tx = event_tx.clone();
                             let picker = thread_picker.clone();
                             tokio::task::spawn_blocking(move || -> Result<(), Error> {
-                                    use mupdf::{Colorspace, Matrix, Document as MuDocument};
+                                use mupdf::{Colorspace, Document as MuDocument, Matrix};
 
-                                    let path_str = path.to_str().ok_or_else(|| Error::Generic("invalid utf-8 in path".to_owned()))?;
-                                    let doc = MuDocument::open(path_str)?;
-                                    let page_count = doc.page_count()?;
-                                    let font_size = picker.font_size();
-                                    let pixel_width =
-                                        available.width as f32 * font_size.width as f32;
+                                let path_str = path.to_str().ok_or_else(|| {
+                                    Error::Generic("invalid utf-8 in path".to_owned())
+                                })?;
+                                let doc = MuDocument::open(path_str)?;
+                                let page_count = doc.page_count()?;
+                                let font_size = picker.font_size();
+                                let pixel_width = available.width as f32 * font_size.width as f32;
 
-                                    for idx in 0..page_count {
-                                        let page = doc.load_page(idx)?;
-                                        let bounds = page.bounds()?;
-                                        let page_width = bounds.x1 - bounds.x0;
-                                        let scale =
-                                            if page_width > 0.0 { pixel_width / page_width } else { 1.0 };
-                                        let matrix = Matrix::new_scale(scale, scale);
-                                        let pixmap = page
-                                            .to_pixmap(&matrix, &Colorspace::device_rgb(), 0.0, false)?;
-                                        let width = pixmap.width();
-                                        let height = pixmap.height();
-                                        let samples = pixmap.samples().to_vec();
-                                        let dyn_img = image::DynamicImage::ImageRgb8(
-                                            image::RgbImage::from_raw(width, height, samples).ok_or_else(|| Error::ImageLoad(
-                                                path_str.to_owned(),
-                                                "could not create RBGA image from pixmap".to_owned(),
-                                            ))?);
-                                        let resize =
-                                            Resize::Fit(Some(ratatui_image::FilterType::Lanczos3));
-                                        let page_available =
-                                            Size::new(available.width, u16::MAX);
-                                        let size = resize.size_for(
-                                            &dyn_img,
-                                            picker.font_size(),
-                                            page_available,
-                                        );
-                                        let proto = SlicedProtocol::new(&picker, dyn_img, Some(size))?;
-                                        event_tx.send(Event::PdfPageLoaded(idx as usize, proto))?;
-                                    }
+                                for idx in 0..page_count {
+                                    let page = doc.load_page(idx)?;
+                                    let bounds = page.bounds()?;
+                                    let page_width = bounds.x1 - bounds.x0;
+                                    let scale = if page_width > 0.0 {
+                                        pixel_width / page_width
+                                    } else {
+                                        1.0
+                                    };
+                                    let matrix = Matrix::new_scale(scale, scale);
+                                    let pixmap = page.to_pixmap(
+                                        &matrix,
+                                        &Colorspace::device_rgb(),
+                                        0.0,
+                                        false,
+                                    )?;
+                                    let width = pixmap.width();
+                                    let height = pixmap.height();
+                                    let samples = pixmap.samples().to_vec();
+                                    let dyn_img = image::DynamicImage::ImageRgb8(
+                                        image::RgbImage::from_raw(width, height, samples)
+                                            .ok_or_else(|| {
+                                                Error::ImageLoad(
+                                                    path_str.to_owned(),
+                                                    "could not create RBGA image from pixmap"
+                                                        .to_owned(),
+                                                )
+                                            })?,
+                                    );
+                                    let resize =
+                                        Resize::Fit(Some(ratatui_image::FilterType::Lanczos3));
+                                    let page_available = Size::new(available.width, u16::MAX);
+                                    let size = resize.size_for(
+                                        &dyn_img,
+                                        picker.font_size(),
+                                        page_available,
+                                    );
+                                    let proto = SlicedProtocol::new(&picker, dyn_img, Some(size))?;
+                                    event_tx.send(Event::PdfPageLoaded(idx as usize, proto))?;
+                                }
                                 Ok(())
                             })
                             .await??;
@@ -314,20 +330,21 @@ pub fn worker_thread(
                                 let resize = Resize::Fit(Some(ratatui_image::FilterType::Lanczos3));
                                 let (dyn_img, size) = if let Some((path, available)) = image {
                                     let dyn_img = image::ImageReader::open(path)?.decode()?;
-                                    let size = resize.size_for(&dyn_img, picker.font_size(), available);
+                                    let size =
+                                        resize.size_for(&dyn_img, picker.font_size(), available);
                                     (dyn_img, size)
                                 } else {
                                     let bytes = include_bytes!("../assets/logo.png");
                                     (
-                                        image::ImageReader::with_format(std::io::Cursor::new(bytes), image::ImageFormat::Png).decode()?,
+                                        image::ImageReader::with_format(
+                                            std::io::Cursor::new(bytes),
+                                            image::ImageFormat::Png,
+                                        )
+                                        .decode()?,
                                         crate::view::WELCOME_LOGO_SIZE.into(),
                                     )
                                 };
-                                let proto = picker.new_protocol(
-                                    dyn_img,
-                                    size,
-                                    resize,
-                                )?;
+                                let proto = picker.new_protocol(dyn_img, size, resize)?;
                                 event_tx.send(Event::RootImageLoaded(proto))?;
                                 Ok(())
                             })
@@ -335,13 +352,14 @@ pub fn worker_thread(
                         }
                     }
 
-                    Ok::<(),Error>(())
-                }.await;
+                    Ok::<(), Error>(())
+                }
+                .await;
 
                 match result {
                     Err(Error::ThreadClosed) => break, // Goodbye.
                     Err(err) => event_tx.send(Event::WorkerError(err))?,
-                    Ok(()) => {}, // Keep processing.
+                    Ok(()) => {} // Keep processing.
                 }
             }
 
@@ -354,6 +372,177 @@ pub fn worker_thread(
         }
         result
     })
+}
+
+/// Parse a single markdown blob and emit `Event::Parsed` for each section.
+///
+/// Returns the next section id that would be assigned if parsing continued
+/// (so the caller can pass it to the next file in multi-file mode) and the
+/// list of `SectionEvent`s that still need post-processing (image loading,
+/// header rendering, code highlighting, reference definition application).
+///
+/// `current_basepath` is the basepath of the file currently being parsed; it
+/// is attached to every `SectionEvent::Image` produced for this file so the
+/// worker can resolve relative image links against the correct file.
+#[expect(clippy::too_many_arguments)]
+fn parse_one_file(
+    parser: &mut MdFrier,
+    event_tx: &Sender<Event>,
+    document_id: DocumentId,
+    width: u16,
+    text: &str,
+    current_basepath: Option<&std::path::Path>,
+    has_renderer: bool,
+    config: &Config,
+    starting_section_id: usize,
+) -> Result<(usize, Vec<SectionEvent>), Error> {
+    let lines = parser.parse(width, text, &config.theme)?;
+    let mut section_iter =
+        SectionIterator::with_starting_id(lines, &config.theme, starting_section_id);
+    let mut post_parse_events = Vec::new();
+    for section in &mut section_iter {
+        match &section.content {
+            SectionContent::Lines(lines) => {
+                for (_, extras) in lines {
+                    for extra in extras {
+                        if let LineExtra::Link { reference, .. } = extra
+                            && let LinkReference::ReferenceDefinition { id, url } = reference
+                        {
+                            post_parse_events.push(SectionEvent::ReferenceDefinition {
+                                id: id.clone(),
+                                url: url.clone(),
+                            });
+                        }
+                    }
+                }
+                event_tx.send(Event::Parsed(document_id, section))?;
+            }
+            SectionContent::Code(language, lines) => {
+                post_parse_events.push(SectionEvent::Code(
+                    section.id,
+                    language.clone(),
+                    lines.iter().map(|(line, _)| line.clone()).collect(),
+                ));
+                event_tx.send(Event::Parsed(document_id, section))?;
+            }
+            SectionContent::Image(_, _, _, _) => {
+                unreachable!("SectionIterator produced Image");
+            }
+            SectionContent::ImagePlaceholder(link, lines) => {
+                let section_id = section.id;
+                let link = link.clone();
+                let has_trailing_blank = lines
+                    .last()
+                    .map(|(line, _)| line.spans.is_empty())
+                    .unwrap_or_default();
+                event_tx.send(Event::Parsed(document_id, section))?;
+                post_parse_events.push(SectionEvent::Image(
+                    section_id,
+                    link,
+                    has_trailing_blank,
+                    current_basepath.map(PathBuf::from),
+                ));
+            }
+            SectionContent::Header(_, _, _) => {
+                if !config.theme.has_text_size_protocol.unwrap_or_default() {
+                    unreachable!("SectionIterator produced Header without text-size-protocol");
+                }
+                event_tx.send(Event::Parsed(document_id, section))?;
+            }
+            SectionContent::HeaderPlaceholder(text, tier, _) => {
+                if config.theme.has_text_size_protocol.unwrap_or_default() {
+                    unreachable!(
+                        "SectionIterator produced HeaderPlaceholder with text-size-protocol"
+                    );
+                }
+                let section_id = section.id;
+                let text = text.clone();
+                let tier = *tier;
+                event_tx.send(Event::Parsed(document_id, section))?;
+                if has_renderer {
+                    post_parse_events.push(SectionEvent::Header(section_id, text, tier));
+                }
+            }
+            SectionContent::FileSeparator { .. } => {
+                unreachable!("SectionIterator produced FileSeparator");
+            }
+        }
+    }
+    let next_section_id = section_iter.next_id();
+    Ok((next_section_id, post_parse_events))
+}
+
+/// Apply the image cache to the post-parse events.
+///
+/// Events whose `Image` or `Header` payload has a matching cache entry are
+/// converted into `Event::ImageLoaded` / `Event::HeaderLoaded` immediately and
+/// not returned. `ReferenceDefinition` events are always applied inline.
+/// Everything else is returned so the caller can hand it to
+/// `process_post_parse_events` for async work.
+fn drain_image_cache(
+    event_tx: &Sender<Event>,
+    document_id: DocumentId,
+    width: u16,
+    image_cache: &mut ImageCache,
+    config_max_image_height: u16,
+    post_parse_events: Vec<SectionEvent>,
+) -> Result<Vec<SectionEvent>, Error> {
+    let mut uncached_post_parse_events = Vec::new();
+    for event in post_parse_events {
+        match &event {
+            SectionEvent::Image(section_id, link, has_trailing_blank, _section_basepath) => {
+                if let Some((proto, size, max_size)) = image_cache.images.remove(&link.url) {
+                    if width == max_size.width && config_max_image_height >= max_size.height {
+                        event_tx.send(Event::ImageLoaded(
+                            document_id,
+                            *section_id,
+                            link.clone(),
+                            (proto, size, max_size),
+                            *has_trailing_blank,
+                        ))?;
+                        log::debug!(
+                            "image cache hit: {max_size:?} vs {width}x{config_max_image_height}, {size:?}, {}",
+                            link.url
+                        );
+                    } else {
+                        log::debug!(
+                            "image cache hit but different max width ({width}x{config_max_image_height} vs {max_size}): {size:?}, {}",
+                            link.url
+                        );
+                        uncached_post_parse_events.push(event);
+                    }
+                } else {
+                    log::debug!("image cache miss: {}", link.url);
+                    uncached_post_parse_events.push(event);
+                }
+            }
+            SectionEvent::Header(section_id, text, tier) => {
+                let key = (text.clone(), *tier);
+                if let Some(protos) = image_cache.headers(width).and_then(|hc| hc.remove(&key)) {
+                    log::debug!("header cache hit: {key:?}");
+                    event_tx.send(Event::HeaderLoaded(
+                        document_id,
+                        *section_id,
+                        protos
+                            .into_iter()
+                            .map(|proto| (text.clone(), *tier, proto))
+                            .collect(),
+                    ))?;
+                } else {
+                    log::debug!("header cache miss: {key:?}");
+                    uncached_post_parse_events.push(event);
+                }
+            }
+            SectionEvent::ReferenceDefinition { id, url } => {
+                event_tx.send(Event::ReferenceDefinition {
+                    id: format!("[{id}]"),
+                    url: url.clone(),
+                })?;
+            }
+            _ => uncached_post_parse_events.push(event),
+        }
+    }
+    Ok(uncached_post_parse_events)
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -387,7 +576,7 @@ async fn process_post_parse_events(
 
         set.spawn(async move {
             match event {
-                SectionEvent::Image(section_id, link, has_trailing_blank) => {
+                SectionEvent::Image(section_id, link, has_trailing_blank, section_basepath) => {
                     let url = link.url.clone(); // For potential errors
                     // Load fresh image
                     match image_section(
@@ -395,6 +584,7 @@ async fn process_post_parse_events(
                         config_max_image_height,
                         width,
                         document_source.clone(),
+                        section_basepath.as_deref(),
                         client.clone(),
                         section_id,
                         link,

--- a/src/worker/sections.rs
+++ b/src/worker/sections.rs
@@ -7,6 +7,7 @@
 //! - All other lines are aggregated into text sections
 
 use std::iter::Peekable;
+use std::path::PathBuf;
 
 use mdfrier::link_tracker::TrackedUrl;
 use mdfrier::ratatui::{Theme as _, render_line};
@@ -18,7 +19,7 @@ use crate::document::{LineExtra, LinkReference, Section, SectionContent, Section
 
 /// Events produced during section iteration that need post-processing.
 pub enum SectionEvent {
-    Image(SectionID, MarkdownLink, bool),
+    Image(SectionID, MarkdownLink, bool, Option<PathBuf>),
     Header(SectionID, String, u8),
     ReferenceDefinition { id: String, url: String },
     Code(SectionID, String, Vec<ratatui::prelude::Line<'static>>),
@@ -27,7 +28,7 @@ pub enum SectionEvent {
 impl std::fmt::Display for SectionEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SectionEvent::Image(_, link, _has_trailing_blank) => write!(f, "Image({link})"),
+            SectionEvent::Image(_, link, _has_trailing_blank, _) => write!(f, "Image({link})"),
             SectionEvent::Header(_, text, level) => write!(f, "H{level}({text})"),
             SectionEvent::ReferenceDefinition { id, url } => write!(f, "Ref({id} => {url})"),
             SectionEvent::Code(_, lang, _) => write!(f, "Code({lang})"),
@@ -44,6 +45,7 @@ pub struct SectionIterator<'a, I: Iterator<Item = Line>> {
 
 impl<'a, I: Iterator<Item = Line>> SectionIterator<'a, I> {
     /// Create a new section iterator from a line iterator.
+    #[cfg(test)]
     pub fn new(inner: I, theme: &'a Theme) -> Self {
         SectionIterator {
             inner: inner.peekable(),
@@ -52,13 +54,33 @@ impl<'a, I: Iterator<Item = Line>> SectionIterator<'a, I> {
         }
     }
 
+    /// Like `new` but starts assigning section ids at `starting_id`.
+    /// Used by the worker in multi-file mode so each file's sections do not
+    /// collide with the previous file's section ids.
+    pub fn with_starting_id(inner: I, theme: &'a Theme, starting_id: usize) -> Self {
+        SectionIterator {
+            inner: inner.peekable(),
+            theme,
+            section_id: starting_id,
+        }
+    }
+
     /// Get the last section ID that was assigned (for ParseDone).
+    #[cfg(test)]
+    #[expect(dead_code)]
     pub fn last_section_id(&self) -> Option<usize> {
         if self.section_id == 0 {
             None
         } else {
             Some(self.section_id - 1)
         }
+    }
+
+    /// The next section id that will be assigned. Always > 0 after at least
+    /// one section has been emitted. Useful for the worker to continue the
+    /// id sequence across multiple `SectionIterator`s in multi-file mode.
+    pub fn next_id(&self) -> usize {
+        self.section_id
     }
 
     pub fn next_section_id(&mut self) -> SectionID {


### PR DESCRIPTION
Closes #180

## What

`mdfried` now accepts more than one positional `[SOURCE]` and
renders them in sequence, separated by a thin bat-style rule line
that includes the next file's name. `mdfried a.md b.md c.md` works
end-to-end.

```sh
mdfried a.md b.md
```

renders `a.md`, then a single muted separator line (`\u2500\u2500\u2500\u2500\u2500
File: b.md \u2500\u2500...`), then `b.md`. Markdown content inside each
file is not modified.

## Why

A shell glob like `mdfried **/PRO*.md` expands to multiple paths and
currently fails with clap's generic `unexpected argument ... found`.
The user has to either quote the glob or loop over `mdfried`
manually. First-class multi-source support makes the common case
("show me all PROPOSAL.md files") one command, matching `bat`'s
ergonomics.

## How

- New `DocumentSource::MultiFile { entries: Vec<MultiFileEntry> }`
  variant carries the pre-loaded text per file, so the worker can
  parse each in order without re-reading the filesystem.
- New `SectionContent::FileSeparator { filename }` variant is what
  the view layer renders as a single muted line, using the same
  `\u2500` character `bat` uses.
- New `Cmd::ParseMulti` command asks the worker to parse a list of
  (text, basepath) pairs. `parse_one_file` and `drain_image_cache`
  are extracted from the existing `Cmd::Parse` flow so both arms
  share the parsing and image-cache code.
- Each section produced by `parse_one_file` in multi-file mode
  carries the current file's basepath through `SectionEvent::Image`
  to `image_section`, so relative `![](img.png)` references resolve
  against the correct file. Single-file behaviour is unchanged because
  `image_section` still falls back to `document_source.read()` when
  no basepath override is given.
- `Model::parse_multi` sends `Cmd::ParseMulti` to the worker.
- The CLI validates the source list before any I/O: a friendly usage
  error is returned for `--watch` + multiple sources, multiple `-`,
  mixed stdin + files, and URLs alongside file paths.

## v1 scope (intentional)

- File paths only. URLs, `github:owner/repo`, and `-` (stdin)
  remain single-source for v1; mixing them with file paths fails
  with a friendly usage error pointing at the limitation.
- A separator is rendered *before* every file (including the first),
  matching `bat`.
- `--watch` rejects more than one source.
- No new dependencies.

A new unit test `multi_file_renders_with_file_separator` builds a
Model with a `MultiFile` source, calls `parse_multi` for two
trivial markdown files, and asserts the resulting sections include a
`FileSeparator` for each file with the user-supplied path verbatim,
and that the rendered buffer contains the bat-style rule character
around each filename. The full test suite (`cargo test --bin mdfried`)
passes (34/34). `cargo clippy --all-targets -- -D warnings` and
`cargo doc --no-deps` are clean. `cargo build --release` works.

## Test plan for the reviewer

```sh
# Reject the failure mode
mdfried a.md b.md c.md      # works, renders in order
mdfried **/*.md             # works, the original report

# Rejections (should print a friendly usage error and exit 2):
mdfried a.md b.md --watch
mdfried a.md https://example.com/foo.md
mdfried - a.md
mdfried a.md -
```

## Out of scope (v2)

- URL / github / stdin mixed with file paths.
- Multi-file `--watch`.
- A multi-file `:back` history.
- Per-file `deep_fry` overrides.

## Independent of #178 / #179

This PR does not interact with #178 or #179. When this lands, the
friendly error in #179 becomes unnecessary because the rejection no
longer happens for the file-path case.