### PR TITLE
feat: add preserve_list_ordinals config option

### DIFF
--- a/mdfrier/src/lib.rs
+++ b/mdfrier/src/lib.rs
@@ -255,7 +255,8 @@ impl MdFrier {
         mapper: &'a M,
     ) -> Result<LineIterator<'a, M>, MarkdownParseError> {
         let tree = self.parser.parse(text, None).ok_or(MarkdownParseError)?;
-        let iter = MdIterator::new(tree, &mut self.inline_parser, text);
+        let mut iter = MdIterator::new(tree, &mut self.inline_parser, text);
+        iter.preserve_list_ordinals(mapper.preserve_list_ordinals());
         Ok(LineIterator::new(iter, width, mapper))
     }
 }
@@ -611,6 +612,113 @@ Quote break.
         let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
         let output = lines_to_string(&lines);
         insta::assert_snapshot!(output);
+    }
+
+    struct PreserveMapper;
+    impl Mapper for PreserveMapper {
+        fn preserve_list_ordinals(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn ordinals_preserved() {
+        // preserve_list_ordinals = true: source numbers are kept exactly as written
+        let input = "1. a\n3. b\n5. c\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &PreserveMapper).unwrap().collect();
+        assert_eq!(lines_to_string(&lines), "1. a\n3. b\n5. c");
+    }
+
+    #[test]
+    fn ordinals_preserved_nested() {
+        // preserve mode must not renumber items in nested structures
+        let input = "3. a\n   - inner\n7. b\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &PreserveMapper).unwrap().collect();
+        assert_eq!(lines_to_string(&lines), "3. a\n   - inner\n7. b");
+    }
+
+    #[test]
+    fn ordinals_sequential_from_1() {
+        // Non-sequential source numbers are renumbered starting from the first item's number
+        let input = "1. a\n3. b\n5. c\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        assert_eq!(lines_to_string(&lines), "1. a\n2. b\n3. c");
+    }
+
+    #[test]
+    fn ordinals_sequential_from_first() {
+        // Renumbering starts from the first item's number, not always 1
+        let input = "2. a\n7. b\n4. c\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        assert_eq!(lines_to_string(&lines), "2. a\n3. b\n4. c");
+    }
+
+    #[test]
+    fn ordinals_sequential_nested() {
+        // Each nested ordered list has its own counter independent of the outer list.
+        // Note: tree-sitter-markdown only recognises a tight nested ordered sub-list when
+        // it starts at 1. A sub-list starting at any other number is parsed as paragraph
+        // continuation text of the parent item, so we use 1 here to get a real sub-list.
+        let input = "3. a\n   1. inner-a\n   9. inner-b\n7. b\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        // inner 9 → 2 (continues from 1), outer 7 → 4 (continues from 3)
+        assert_eq!(
+            lines_to_string(&lines),
+            "3. a\n   1. inner-a\n   2. inner-b\n4. b"
+        );
+    }
+
+    #[test]
+    fn ordinals_sequential_nested_unordered() {
+        // A nested unordered list must not reset the outer ordered counter.
+        let input = "3. a\n   - inner-a\n   - inner-b\n7. b\n";
+        let mut frier = MdFrier::new().unwrap();
+        let lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        // outer 7 → 4 (continues from 3, despite the nested unordered items)
+        assert_eq!(
+            lines_to_string(&lines),
+            "3. a\n   - inner-a\n   - inner-b\n4. b"
+        );
+    }
+
+    #[test]
+    fn ordinals_complex_nested() {
+        // Exercises sequential renumbering and preserve mode together across:
+        // - an outer ordered list starting at a non-1 number
+        // - a nested unordered sub-list (must not disturb the outer counter)
+        // - a nested ordered sub-list with a non-sequential source item (9 → 2)
+        // - a two-digit outer item (11 → 5)
+        //
+        // Inner ordered sub-list starts at 1 because tree-sitter-markdown parses
+        // tight nested ordered sub-lists as paragraph continuation when they start
+        // at any other number.
+        let input = "\
+3. outer-a
+   - unordered-1
+   - unordered-2
+7. outer-b
+   1. inner-1
+   9. inner-2
+11. outer-c
+";
+        let mut frier = MdFrier::new().unwrap();
+
+        let seq_lines: Vec<_> = frier.parse(80, input, &DefaultMapper).unwrap().collect();
+        assert_eq!(
+            lines_to_string(&seq_lines),
+            "3. outer-a\n   - unordered-1\n   - unordered-2\n4. outer-b\n   1. inner-1\n   2. inner-2\n5. outer-c",
+        );
+
+        let pre_lines: Vec<_> = frier.parse(80, input, &PreserveMapper).unwrap().collect();
+        assert_eq!(
+            lines_to_string(&pre_lines),
+            "3. outer-a\n   - unordered-1\n   - unordered-2\n7. outer-b\n   1. inner-1\n   9. inner-2\n11. outer-c",
+        );
     }
 
     #[test]

--- a/mdfrier/src/lines.rs
+++ b/mdfrier/src/lines.rs
@@ -85,9 +85,8 @@ impl<'a, M: Mapper> LineIterator<'a, M> {
 
     /// Process the next MdSection and queue its lines
     fn process_next_section(&mut self) -> bool {
-        let section = match self.inner.next() {
-            Some(s) => s,
-            None => return false,
+        let Some(section) = self.inner.next() else {
+            return false;
         };
 
         let in_list = section

--- a/mdfrier/src/mapper.rs
+++ b/mdfrier/src/mapper.rs
@@ -204,6 +204,14 @@ pub trait Mapper {
         false
     }
 
+    /// Preserve original ordinal numbers in ordered lists.
+    ///
+    /// When `false` (default), ordered list items are renumbered sequentially starting from the
+    /// first item's number. When `true`, the original source numbers are preserved.
+    fn preserve_list_ordinals(&self) -> bool {
+        false
+    }
+
     /// Internal "has text-size-protocol" marker
     ///
     /// If true, then header width is adjusted proportionally to the header tier for wrapping.

--- a/mdfrier/src/markdown.rs
+++ b/mdfrier/src/markdown.rs
@@ -21,10 +21,14 @@ pub(crate) struct MdIterator<'a> {
     depth: usize,
     /// Depth of the last ListItem that has emitted content (for continuation detection).
     list_item_content_depth: Option<usize>,
+    /// Sequential ordered-list counter stack. `None` = preserve-source mode.
+    /// In sequential mode each entry corresponds to one open ordered list (innermost last);
+    /// `None` entry = no item seen yet, `Some(n)` = last assigned number at that depth.
+    list_ordinal: Option<Vec<Option<u32>>>,
 }
 
 impl<'a> MdIterator<'a> {
-    pub fn new(tree: Tree, inline_parser: &'a mut Parser, source: &'a str) -> Self {
+    pub(crate) fn new(tree: Tree, inline_parser: &'a mut Parser, source: &'a str) -> Self {
         let tree = Box::new(tree);
         let cursor =
             // SAFETY:
@@ -41,7 +45,16 @@ impl<'a> MdIterator<'a> {
             context: Vec::new(),
             depth: 0,
             list_item_content_depth: None,
+            list_ordinal: Some(Vec::new()),
         }
+    }
+
+    pub(crate) fn preserve_list_ordinals(&mut self, preserve_list_ordinals: bool) {
+        self.list_ordinal = if preserve_list_ordinals {
+            None
+        } else {
+            Some(Vec::new())
+        };
     }
 }
 
@@ -58,6 +71,17 @@ impl Iterator for MdIterator<'_> {
 
             // Check if current node is a container and push to context
             if let Some(container) = self.node_to_container(node) {
+                if let Some(stack) = &mut self.list_ordinal {
+                    match &container {
+                        MdContainer::List(ListMarker::Ordered(_)) => stack.push(None),
+                        MdContainer::ListItem(ListMarker::Ordered(n)) => {
+                            if let Some(top) = stack.last_mut() {
+                                *top = Some(*n);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
                 self.context.push((self.depth, container));
             }
 
@@ -71,11 +95,18 @@ impl Iterator for MdIterator<'_> {
                         // Pop containers that are no longer ancestors
                         while self.context.last().is_some_and(|(d, _)| *d >= self.depth) {
                             let popped = self.context.pop();
-                            // If we're leaving a ListItem, reset the content tracking
-                            if let Some((d, MdContainer::ListItem(_))) = popped {
-                                if self.list_item_content_depth == Some(d) {
-                                    self.list_item_content_depth = None;
+                            match popped {
+                                Some((d, MdContainer::ListItem(_))) => {
+                                    if self.list_item_content_depth == Some(d) {
+                                        self.list_item_content_depth = None;
+                                    }
                                 }
+                                Some((_, MdContainer::List(ListMarker::Ordered(_)))) => {
+                                    if let Some(stack) = &mut self.list_ordinal {
+                                        stack.pop();
+                                    }
+                                }
+                                _ => {}
                             }
                         }
                     } else {
@@ -327,19 +358,34 @@ impl<'a> MdIterator<'a> {
             "list" => {
                 for child in node.children(&mut node.walk()) {
                     if child.kind() == "list_item" {
-                        return Some(MdContainer::List(self.extract_list_marker(child)));
+                        return Some(MdContainer::List(self.extract_list_marker(child, None)));
                     }
                 }
                 Some(MdContainer::List(ListMarker::Unordered(BulletStyle::Dash)))
             }
-            "list_item" => Some(MdContainer::ListItem(self.extract_list_marker(node))),
+            "list_item" => {
+                let prev_ordinal = self
+                    .list_ordinal
+                    .as_ref()
+                    .and_then(|list| list.last().copied())
+                    .flatten();
+                Some(MdContainer::ListItem(
+                    self.extract_list_marker(node, prev_ordinal),
+                ))
+            }
             "block_quote" => Some(MdContainer::Blockquote(BlockquoteMarker)),
             _ => None,
         }
     }
 
     #[expect(clippy::string_slice)]
-    fn extract_list_marker(&self, list_item: Node<'a>) -> ListMarker {
+    fn extract_list_marker(
+        &self,
+        list_item: Node<'a>,
+        // None  = use source number (first item in sequential mode, or preserve mode)
+        // Some(n) = last assigned number at this depth; emit n + 1
+        prev_ordinal: Option<u32>,
+    ) -> ListMarker {
         let mut first_char = '-';
         let mut task: Option<bool> = None;
 
@@ -370,12 +416,16 @@ impl<'a> MdIterator<'a> {
             Some(false) => ListMarker::TaskUnchecked(bullet),
             None if first_char.is_ascii_digit() => {
                 // Parse ordered list number
-                let num: u32 = self.source[list_item.byte_range()]
-                    .chars()
-                    .take_while(|c| c.is_ascii_digit())
-                    .fold(0_u32, |acc, c| {
-                        acc.saturating_mul(10)
-                            .saturating_add(c.to_digit(10).unwrap_or(0))
+                let num: u32 = prev_ordinal
+                    .map(|n| n.saturating_add(1))
+                    .unwrap_or_else(|| {
+                        self.source[list_item.byte_range()]
+                            .chars()
+                            .take_while(|c| c.is_ascii_digit())
+                            .fold(0_u32, |acc, c| {
+                                acc.saturating_mul(10)
+                                    .saturating_add(c.to_digit(10).unwrap_or(0))
+                            })
                     });
                 ListMarker::Ordered(if num == 0 { 1 } else { num })
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,7 @@ pub struct Theme {
     pub header_color: Option<Color>,
     pub hide_urls: Option<bool>,
     pub has_text_size_protocol: Option<bool>,
+    pub preserve_list_ordinals: Option<bool>,
 }
 
 // Delegate to StyledMapper for defaults
@@ -224,6 +225,9 @@ impl Mapper for Theme {
     fn has_text_size_protocol(&self) -> bool {
         self.has_text_size_protocol.unwrap_or_default()
     }
+    fn preserve_list_ordinals(&self) -> bool {
+        self.preserve_list_ordinals.unwrap_or(false)
+    }
 }
 
 // Delegate to DefaultTheme for defaults
@@ -312,6 +316,7 @@ impl Theme {
             hide_urls: Some(Theme::hide_urls(&theme)),
             header_color: Some(Color::from_str("#FFFFFF").unwrap_or_default()),
             has_text_size_protocol: None,
+            preserve_list_ordinals: Some(false),
         }
     }
 }


### PR DESCRIPTION
By default, ordered list items are renumbered sequentially starting from the first item's source number. Set `preserve_list_ordinals = true` under `[theme]` to keep the original source numbers instead.

Note: tree-sitter-markdown only recognises tight nested ordered sub-lists when they start at 1; any other start number is parsed as paragraph continuation text of the parent item. So this might not be the expected result yet for every markdown style.

Fixes #182