### PR TITLE
ignore_text_sizing_protocol

### DIFF
--- a/assets/docs/CHANGELOG.md
+++ b/assets/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Added
+- `ignore_text_sizing_protocol` config option  
+  Set `ignore_text_sizing_protocol = true` to suppress probing for the Text Sizing Protocol on startup.
+  Headers will always be rendered as images instead. Useful when a terminal falsely reports protocol
+  support, or when the image-rendered look is preferred.
 - `preserve_list_ordinals` config option  
   Set `preserve_list_ordinals = true` under `[theme]` to keep original source numbers in ordered
   lists instead of renumbering sequentially.

--- a/assets/docs/help_configuration.md
+++ b/assets/docs/help_configuration.md
@@ -20,6 +20,14 @@ stdio_query_timeout_ms = 2000
 The timeout in milliseconds to wait for a TTY response. It may be necessary to increaso on older or exotic machines, OSs or terminals, such as Windows.
 
 ```toml
+ignore_text_sizing_protocol = false
+```
+Suppress probing for the [Text Sizing Protocol](https://sw.kovidgoyal.net/kitty/text-sizing-protocol/) on startup.
+When `true`, headers are always rendered as images (using the configured font) instead of using the
+terminal's native text scaling. Useful if your terminal falsely reports support for the protocol, or
+if you prefer the image-rendered look regardless.
+
+```toml
 max_image_height = 30
 ```
 The maximum image height as terminal row count. The width is kept proportional at the aspect ratio, and capped at the viewport width.

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ impl From<UserConfig> for Config {
 pub struct UserConfig {
     pub font_family: Option<String>,
     pub stdio_query_timeout_ms: Option<u64>,
+    pub ignore_text_sizing_protocol: Option<bool>,
     pub padding: Option<Padding>,
     pub max_image_height: Option<u16>,
     pub watch_debounce_milliseconds: Option<u64>,
@@ -408,6 +409,7 @@ pub fn print_default() -> Result<(), Error> {
     let user_config = UserConfig {
         font_family: Some("your-font-name".to_owned()),
         stdio_query_timeout_ms: Some(2000),
+        ignore_text_sizing_protocol: Some(false),
         padding: Some(config.padding),
         max_image_height: Some(config.max_image_height),
         watch_debounce_milliseconds: Some(config.watch_debounce_milliseconds),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -72,7 +72,7 @@ pub fn setup_graphics(
                 .stdio_query_timeout_ms
                 .map(Duration::from_millis)
                 .unwrap_or_else(|| QueryStdioOptions::default().timeout),
-            text_sizing_protocol: true,
+            text_sizing_protocol: !config.ignore_text_sizing_protocol.unwrap_or(false),
             terminal_background_color_osc: true,
             ..Default::default()
         })?;


### PR DESCRIPTION
Option to suppress checking for, and therefore using, the text-sizing protocol.

There are still some issues with the letter spacing with some font / size combination. Not sure if the root cause is incorrect font size reported by the terminal, or still some logic bug on our side.

Closes #92.