### PR TITLE
also ignore snapshots on riscv64

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -438,7 +438,7 @@ impl std::fmt::Debug for Event {
 mod tests {
     use std::{sync::mpsc, thread::JoinHandle};
 
-    #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
     use insta::assert_snapshot;
     use ratatui::{Terminal, backend::TestBackend, layout::Size, text::Line};
     use ratatui_image::picker::{Picker, ProtocolType};
@@ -557,7 +557,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("first parse image previews", terminal.backend());
         // Must load an image.
         poll_images_done(&mut model);
@@ -566,7 +566,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("first parse done", terminal.backend());
 
         teardown(model, worker);
@@ -615,7 +615,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("reload move image up", terminal.backend());
 
         model
@@ -637,7 +637,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("reload move image down", terminal.backend());
 
         teardown(model, worker);
@@ -686,7 +686,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("reload add image preview", terminal.backend());
         // Must load an image.
         poll_images_done(&mut model);
@@ -695,7 +695,7 @@ Goodbye."#,
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("reload add image done", terminal.backend());
         teardown(model, worker);
     }
@@ -741,7 +741,7 @@ Goodbye.
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("duplicate image preview", terminal.backend());
         // Must load an image.
         poll_images_done(&mut model);
@@ -750,7 +750,7 @@ Goodbye.
                 view(&model, frame.buffer_mut());
             })
             .unwrap();
-        #[cfg(not(any(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(any(target_os = "macos", target_arch = "aarch64", target_arch = "riscv64")))]
         assert_snapshot!("duplicate image done", terminal.backend());
         teardown(model, worker);
     }


### PR DESCRIPTION
Halfblock image snapshots differ from the recorded x86_64 fixtures on riscv64 by a single cell. This is the same architecture-dependent rasterization already skipped on aarch64 and macOS.